### PR TITLE
Add native batch item operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ No particular order.
 - Optimize the range partition splitting (25% of total space instead of 50%, and see if there is a way to go straight to N partitions vs copying to root range).
 - Update partial range topology within each partition to maintain also range boundaries to skip forwards in range partitions.
 - Proper structured errors thrown to differentiate user vs server errors.
-- Add FokosStd class with helper methods (e.g. paginator for queryItems).
+- Add more FokosStd helper methods (e.g. paginator for queryItems).
 - Enforce the expiration ttl for items.
-- Batch item operations (non-transactions).
 - Use an instance of the FokosDB (without transactions) as the durability ledger for Transaction Coordinators to allow stateless coordinators so that data partitions would be able to start recovery on any of them. It adds an extra hop though in the transaction flow. Or put enough info in the transaction sent to each partition so that they can communicate with the involved partitions to learn the outcome of the transaction.
 - Allow check conditions and filter conditions on any attribute if the data is JSON.
 - Refactor do-partition tests from scratch now that everything is implemented and clean them up without internal knowledge.

--- a/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
+++ b/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
@@ -231,7 +231,6 @@ diagnostics.
 Use a discriminated union for per-item retryable failures. At minimum:
 
 - `pending_lock`;
-- `migration_in_progress`;
 - `partition_over_limit`;
 - `transient_error`.
 

--- a/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
+++ b/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
@@ -1,125 +1,58 @@
-# Native Batch Item Operations
+# Native Batch Item Operations — Implementation Plan
 
-Status: **implemented on `feat/batch-item-ops`**. This document captures the GitHub issue draft and
-the implementation contract for native, non-transactional `BatchGet` / `BatchWrite` style operations
-in FokosDB.
+Status: **implemented on `feat/batch-item-ops`**. This plan defines native, non-transactional
+`BatchGet` / `BatchWrite` operations alongside `putItem`/`getItem`/`deleteItem`/`queryItems`, modeled on
+the DynamoDB `BatchGetItem` / `BatchWriteItem` operations and adapted to fokosdb's hash-partition +
+promoted-range topology. It is the completion record for that work: the public contract, the invariants,
+the milestone history, and the review-driven deviations.
 
-The scope is intentionally narrower than DynamoDB parity and broader than a client-side helper loop.
-The core operations are native FokosDB RPCs that preserve the existing partition routing, migration,
-split, lock, promotion, and retry behavior. `FokosStd` adds optional client-side chunking and bounded
-retry helpers on top of those native operations.
+The scope is intentionally narrower than DynamoDB parity and broader than a client-side helper loop. The
+core operations are native `PartitionDO` RPCs that preserve the existing partition routing, migration,
+split, lock, and promotion behavior. `FokosStd` (M5) adds optional client-side chunking and bounded retry
+on top of the native operations.
 
 ## Source hierarchy and quality bar
 
-Implementation decisions should be resolved in this order:
+Implementation decisions are resolved in this order:
 
-1. Existing FokosDB behavior and style. Match the public API shape in `FokosDB`, the HTTP RPC shape in
+1. **Existing FokosDB behavior and style.** Match the public API shape in `FokosDB`, the HTTP RPC shape in
    `src/index.ts`, the validation style in `transaction-limits.ts`, the split/migration rules in
    `PartitionDO`, and the level of detail in the existing `queryItems` / `KeyCodec` plans.
-2. Official DynamoDB BatchGetItem / BatchWriteItem documentation, used as the semantic baseline for
-   limits, duplicate-key rejection, non-atomic writes, and `UnprocessedKeys` / `UnprocessedItems`:
+2. **Official DynamoDB BatchGetItem / BatchWriteItem docs**, as the semantic baseline for limits,
+   duplicate-key rejection, non-atomic writes, and `UnprocessedKeys` / `UnprocessedItems`:
    - <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html>
    - <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html>
-3. Current Cloudflare Workers / Durable Objects limits, used only to choose safe FokosDB server-side
-   bounds:
+3. **Current Cloudflare Workers / Durable Objects limits**, used only to choose safe server-side bounds:
    - <https://developers.cloudflare.com/workers/platform/limits/>
    - <https://developers.cloudflare.com/durable-objects/platform/limits/>
 
-This work should not be a thin wrapper over existing single-item calls. It should be a native,
-well-factored implementation with tests first around operation semantics, limits, split/migration
-guards, and partial-failure behavior.
+This is not a thin wrapper over single-item calls. It is a native, well-factored implementation with
+tests around operation semantics, limits, split/migration guards, and partial-failure behavior.
 
-## GitHub issue draft
+## 1. DynamoDB parity matrix
 
-### Title
+| DynamoDB feature | fokos decision |
+|---|---|
+| `BatchGetItem` / `BatchWriteItem` request shape | **Adopt** as `batchGetItems({ items })` / `batchWriteItems({ operations })`; keys are `string \| Uint8Array`, encoded via `KeyCodec` at the boundary like every other op |
+| Write op set (`PutRequest` / `DeleteRequest`) | **Adopt** `put` / `delete` only. No `check` (that is a transaction op) |
+| Non-atomic, no rollback | **Adopt**. Per-item independence across *and* within a partition |
+| `ConditionExpression` on batch writes | **Dropped** — DynamoDB has none either; conditional writes stay on `transactWriteItems` |
+| `UnprocessedItems` / `UnprocessedKeys` | **Adopt** as retryable per-item entries, correlated by `inputIndex` |
+| 25-write / 100-read item caps | **Adopt** as `MAX_BATCH_WRITE_ITEMS` / `MAX_BATCH_GET_ITEMS`; the *core* call enforces them, the `FokosStd` helper chunks above them |
+| 16 MB request cap | **Replaced** by fokos byte ceilings: a per-batch `MAX_BATCH_PAYLOAD_BYTES` and a per-op `MAX_BATCH_FORWARDED_SUB_BATCH_BYTES` chosen under the workerd RPC limit |
+| Duplicate keys in one request | **Adopt DynamoDB**: reject the whole batch at preflight |
+| Strongly-consistent reads | **Per-item strong** (each key is owned by one DO). A multi-key batch is **not** a global snapshot — that is `transactGetItems` |
+| Returned attributes on writes | **Dropped** — `BatchWriteItem` returns none; processed entries carry keys only, no version |
+| Auto-chunking + retry helper (DocumentClient) | **`FokosStd`** (M5), a separate client-side layer, not the core wire API |
 
-Native non-transactional BatchGet/BatchWrite operations
+A batch request is therefore: **a flat list of per-item keys (get) or put/delete operations (write),
+preflight-validated, routed per item, applied non-atomically, with retryable per-item failures correlated
+by `inputIndex`.**
 
-### Body
+## 2. Public API
 
-FokosDB's README lists "Batch item operations (non-transactions)" as a TODO. This issue proposes a
-native FokosDB implementation for non-transactional batch reads and writes:
-
-- `batchGetItems({ items })`
-- `batchWriteItems({ operations })`
-
-The goal is a DynamoDB-shaped, FokosDB-native contract rather than full DynamoDB API parity.
-
-#### Scope
-
-- Add public `FokosDB` methods for `batchGetItems` and `batchWriteItems`.
-- Add corresponding HTTP RPC actions.
-- Add a focused operation-semantics note under `docs/agent-plans/`.
-- Add tests for public API behavior, HTTP API behavior, validation, partial failures,
-  split/migration routing, unprocessed retry paths, and request limits.
-
-#### Locked semantics
-
-- Empty batches reject during preflight.
-- Each batch has a hard server-side max item count.
-- Each batch has a hard server-side total payload byte ceiling.
-- Each batch write operation has a hard forwarded sub-batch byte ceiling, so deterministic oversize
-  writes reject during preflight instead of returning retryable `UnprocessedItems`.
-- Server-side split/range fan-out is bounded so one request cannot hit unbounded Durable Object
-  subrequests.
-- `batchWriteItems` supports only `put` and `delete`.
-- `batchWriteItems` has no conditions. Conditional writes remain the job of `transactWriteItems`.
-- Duplicate keys reject the whole batch during preflight.
-- Runtime write failures return retryable `UnprocessedItems`.
-- Runtime read failures return retryable `UnprocessedKeys`.
-- `batchGetItems` is strongly consistent per item, but is not a cross-partition snapshot.
-- Retrying unprocessed puts/deletes is safe but not version-idempotent: last write wins and versions
-  may bump again.
-
-#### Retryable unprocessed cases
-
-Return retryable unprocessed entries for:
-
-- pending transaction locks;
-- migration or split-in-progress guards;
-- partition over-limit / retry-later errors;
-- transient child RPC failures.
-
-#### Implementation constraints
-
-- Do not route batch writes through `TransactionCoordinatorDO`.
-- Do not add SQL migrations.
-- Do not call `validateTransactWriteOperations` directly. Extract shared validation helpers or add
-  batch-specific validation so batch errors are named as batch errors.
-- `batchWriteItems` must call `ensureMigration("batchWriteItems")` before routing, matching the
-  write/transaction migration-guard rule.
-- Forwarded child partitions must re-check migration at their own RPC boundary.
-- Reuse transaction-style multi-item routing via `groupItemsByRouting`, but thread an `inputIndex`
-  through routed work so results can be reconstructed in request order.
-- Reuse the existing single-item local write behavior for pending-lock checks, condition-free
-  upsert/delete, promotion queueing, and split checks.
-
-#### Acceptance criteria
-
-- Empty batches reject.
-- Oversized item count, total payload bytes, or single-operation forwarded bytes are rejected by
-  explicit validation; server-side split/range fan-out is bounded by item-count limits plus DO-side
-  split/sub-batch guards, as defined by the implementation note.
-- Duplicate keys reject.
-- Mixed put/delete batch writes work.
-- Partial write failures return retryable unprocessed items without hiding successful writes.
-- Batch reads preserve input order and report unprocessed keys.
-- Migration tests prove writes do not bypass `ensureMigration`.
-- Existing tests pass.
-
-#### Non-goals
-
-- Full DynamoDB API parity.
-- Conditional batch writes.
-- Atomic batch writes.
-- GSI or index behavior.
-- Automatic retry helper, unless added separately as `FokosStd`.
-
-## Implementation contract
-
-### Public API
-
-Use the same public key shape as the existing single-item and transaction APIs:
+Keys use the same `string | Uint8Array` shape as the single-item and transaction APIs, encoded via
+`KeyCodec` at the `FokosDB` boundary.
 
 ```ts
 type BatchGetItemsOptions = {
@@ -128,153 +61,268 @@ type BatchGetItemsOptions = {
 
 type BatchWriteItemsOptions = {
 	operations: Array<
-		| {
-				operation: "put";
-				hashKey: string | Uint8Array;
-				sortKey?: string | Uint8Array;
-				data: string | Uint8Array;
-				ttlSeconds?: number;
-				ttlEpochUTCSeconds?: number;
-		  }
+		| { operation: "put"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array;
+		    data: string | Uint8Array; ttlSeconds?: number; ttlEpochUTCSeconds?: number }
 		| { operation: "delete"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array }
 	>;
 };
 ```
 
-The final result types should be decided in the implementation PR, but they must make these
-properties explicit:
+Result types (`src/lib/types.ts`):
 
-- results can be correlated back to the original input position;
-- successful items are not hidden by unrelated failures;
-- retryable failures carry enough information for a caller to retry just those entries;
-- hard validation failures throw before any item is applied.
+```ts
+type BatchRetryableFailureReason =
+	| { type: "pending_lock"; conflictingTransactionId?: string }
+	| { type: "partition_over_limit" }
+	| { type: "transient_error"; message?: string };
 
-For `batchWriteItems`, the primary correlation field is `inputIndex`, not key matching. Results may
-also echo keys for ergonomics/debugging, but callers should be able to reconstruct the outcome of the
-request from `inputIndex` alone.
+type BatchItemsMeta = {
+	requestedCount: number; processedCount: number; unprocessedCount: number;
+	rowsRead: number; rowsWritten: number; forwardCount: number; partitionsVisited: number;
+};
 
-Do not return per-applied item versions from the core `batchWriteItems` result. A single `putItem`
-returns a version, but batch write is a partial-success/retry API: it should report processed versus
-unprocessed entries, not become a read-after-write result API. Callers that need versions can read the
-items they care about after the batch completes.
+type BatchGetProcessedItem =
+	| {
+			inputIndex: number;
+			found: true;
+			item: {
+				hashKey: string | Uint8Array;
+				sortKey?: string | Uint8Array;
+				data: string | Uint8Array;
+				ttlEpochUTCSeconds?: number;
+				version: number;
+			};
+	  }
+	| { inputIndex: number; found: false; item: ItemKey };
 
-### Batch write execution
+type BatchGetItemsResult = {
+	items: BatchGetProcessedItem[];
+	unprocessedKeys: Array<{ inputIndex: number; item: ItemKey; reason: BatchRetryableFailureReason }>;
+	meta: BatchItemsMeta;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
 
-`batchWriteItems` is non-atomic across the whole request and non-atomic within one partition. This is
-intentional. Callers that need atomicity must use `transactWriteItems`.
+type BatchWriteItemsResult = {
+	processedItems: Array<{ inputIndex: number; operation: "put" | "delete"; item: ItemKey }>;
+	unprocessedItems: Array<{
+		inputIndex: number;
+		operation: "put" | "delete";
+		item: ItemKey;
+		reason: BatchRetryableFailureReason;
+	}>;
+	meta: BatchItemsMeta;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
+```
 
-The write path should compose existing behavior rather than bypass it:
+`inputIndex` is the correlation authority. Results may echo keys for ergonomics, but a caller must be able
+to reconstruct the full outcome from `inputIndex` alone. `batchWriteItems` deliberately returns **no
+per-applied version** — it is a partial-success/retry API, not a read-after-write; callers that need a
+version read the item afterward.
 
-1. Validate and encode public keys at the `FokosDB` boundary.
-2. Reject empty batches, duplicate keys, unsupported operations, invalid keys, and oversized payloads
-   before any write is attempted.
-3. Pick initial partitions from the client-side topology.
-4. At the `PartitionDO` RPC boundary, call `ensureMigration("batchWriteItems")` before routing.
-5. Use `groupItemsByRouting` to split items into local and forwarded groups.
-6. Keep `inputIndex` on every routed item so destination grouping does not destroy request order.
-7. Forward child groups with `Promise.allSettled`.
-8. Apply local items independently using the same semantics as single-item `putItem` and `deleteItem`:
-   pending-lock check, upsert/delete, promotion queueing, and split checks.
-9. Return successes and retryable unprocessed entries without converting sibling successes into
-   failures.
+## 3. Correctness invariants
 
-The local write implementation should factor the existing single-item local bodies instead of copying
-large blocks. If factoring is too invasive, copying the smallest necessary block is acceptable for the
-first PR, but the behavior must stay aligned with single-item writes.
+1. **`inputIndex` is the correlation authority.** Every processed and unprocessed entry carries the
+   caller's original input position. The core assigns it per call; `FokosStd` re-maps chunk-local indices
+   back to global ones. A returned index outside the request is **result corruption** — fail loud, never
+   silently fall back (`db.ts` echo helpers throw on an unknown `inputIndex`).
+2. **Hard input errors throw before any work.** Empty batch, duplicate `(hashKey, sortKey)`, unsupported
+   op, missing `put` data, oversized item count / total payload / single forwarded op — all reject at
+   preflight, never as retryable `Unprocessed*`.
+3. **`batchWriteItems` is non-atomic and condition-free**, across *and* within a partition. Atomicity is
+   `transactWriteItems`'s job.
+4. **Writes respect the two concurrent state machines, never bypass them.** `ensureMigration` is called
+   (throwing variant) before routing and re-checked at each forwarded child; a batch **write** to a
+   pending-locked item or a migrating-child write RPC failure returns a retryable `Unprocessed*` entry, not
+   a wrong-partition write. (Reads instead tolerate migration via parent-read — invariant 5; `pending_lock`
+   is write-only.) The local apply re-checks per-item ownership so a mid-batch split/promotion cannot strand
+   a write on a former owner.
+5. **`batchGetItems` is per-item strongly consistent, not a snapshot.** Reads tolerate migration by
+   reading the parent (mirrors `getItem`), never throwing.
+6. **`partitionMetas` records partitions that performed local read/write work; pure forwarding-only routers
+   are excluded.** `forwardCount` is subtree-cumulative; `requestedCount` is the global N; processed/
+   unprocessed counts are the *final* state; `FokosStd` concatenates a total visit trail across
+   chunks/retries (no per-attempt count double-counting).
+7. **Retry covers only unprocessed entries, and is not version-idempotent.** Re-applying a put/delete is
+   safe (last-write-wins) but bumps the version again.
 
-### Batch get execution
+## 4. File Map
 
-`batchGetItems` is strongly consistent per key. It is not a global point-in-time snapshot across
-partitions; consistent multi-key snapshots remain the job of `transactGetItems`.
+| Area | File |
+|---|---|
+| Public types (options, results, `BatchItemsMeta`, failure union) | `src/lib/types.ts` |
+| Internal RPC types (`*RpcRequest` / `*RpcResult`, `KeyBytes` keys) | `src/lib/batch-types.ts` |
+| Validation + shared estimators + batch constants | `src/lib/transaction-limits.ts` |
+| Client orchestration (group-by-root, fan-out, echo, aggregate) | `src/lib/db.ts` |
+| `PartitionDO` RPCs + local bodies + split/range forwarding | `src/lib/do-partition.ts` |
+| HTTP RPC actions, valibot schemas, serializers, `runBatchRpc` | `src/index.ts` |
+| Client-side chunking + bounded retry helper | `src/lib/fokos-std.ts` |
+| Tests | `src/lib/{db,do-partition,batch-types,transaction-limits,fokos-std}.test.ts`, `test/http-batch.test.ts` |
 
-Reads should preserve input order and return `found: false` for missing items. Runtime read failures
-that are safe to retry should be returned as `UnprocessedKeys`.
+No SQL migrations. The `items` table and existing store methods are reused as-is.
 
-For migration, reads should keep the same behavior as `getItem`: a migrating child may read directly
-from its parent rather than throwing.
+## 5. Milestones (as implemented, M0–M5)
 
-### Limits
+Each milestone compiled and tested independently and was gate-reviewed before the next began.
 
-The implementation must define explicit server-side limits:
+### M0 — Validation, result types, constants
+- **Scope:** public + RPC types, batch constants, `validateBatchGetItems` / `validateBatchWriteOperations`
+  (shared low-level helpers, batch-specific wording — not `validateTransactWriteOperations`). `FokosDB`
+  methods validate + encode, then throw "not implemented yet".
+- **Files:** `types.ts`, `batch-types.ts`, `transaction-limits.ts`, `db.ts`.
+- **Acceptance:** empty/over-max/duplicate/oversized reject at preflight; duplicate identity computed on
+  **encoded `KeyBytes`** (absent sort key = `[]`), matching the store; conditions / `check` rejected.
+- **Verification:** `transaction-limits.test.ts`, `batch-types.test.ts`, `db.test.ts`.
 
-- max items per batch;
-- max encoded payload bytes per batch;
-- max server-side split/range fan-out or forwarded sub-batches per batch;
-- max forwarded sub-batch payload bytes.
+### M1 — BatchGet end-to-end
+- **Scope:** `FokosDB.batchGetItems` groups by initial `pickPartition` root, one RPC per root group via
+  `Promise.allSettled`, preserves the request `inputIndex` through root/child fan-out, echoes original
+  keys, aggregates `meta`/`partitionMetas`. `PartitionDO.batchGetItems` adds migration parent-read,
+  `groupItemsByRouting` fan-out to children, leaf `partitionMetas`, cumulative `forwardCount`.
+- **Files:** `db.ts`, `do-partition.ts` (`batchGetItems`, `batchGetItemsDirect`, `batchGetItemsLocal`).
+- **Acceptance:** input order preserved; `found: false` for misses; child failures → `UnprocessedKeys`;
+  no `getItem` regression (shared `partitionMeta` helper carries every field).
+- **Verification:** `db.test.ts`, `do-partition.test.ts`.
 
-Do not rely on Cloudflare platform limits as the first line of defense. Pick conservative defaults
-below the current Workers / Durable Objects limits, document the rationale in code, and keep the
-constants easy to tune.
+### M2 — BatchWrite, local / single-partition path
+- **Scope:** `PartitionDO.batchWriteItems` calls `ensureMigration` (throwing) **before** routing; the local
+  loop reuses the single-item bodies — `pendingLockFor` → `pending_lock`, `upsertItem` +
+  `maybeQueuePromotion` + `checkSplits` for put, store delete watermark for delete — per item,
+  non-atomic, siblings preserved.
+- **Files:** `db.ts`, `do-partition.ts` (`batchWriteItems`, `batchWriteItemsLocal`).
+- **Acceptance:** pending-lock → retryable with conflicting tx id; no versions in processed entries;
+  mixed put/delete; partial failure does not hide successes.
+- **Verification:** `do-partition.test.ts`, `db.test.ts`.
 
-At implementation time, re-check the current official Cloudflare Workers limits and Durable Objects
-limits before choosing byte and DO-side sub-batch constants:
+### M3 — BatchWrite split/range forwarding + migration partial-failure
+- **Scope:** forward child sub-batches via `Promise.allSettled`; chunk forwarded ops by the forwarded byte
+  guard; per-item **ownership re-check before every local apply** so a mid-batch split/promotion re-routes
+  rather than mis-writes (no TOCTOU — re-check→write is synchronous, the only `await` is `checkSplits`
+  after the write). Migrating child → retryable `Unprocessed*`.
+- **Files:** `do-partition.ts`, `transaction-limits.ts` (split estimators).
+- **Acceptance:** a single-key item across a completed split forwards and is visible; migrating-child and
+  over-limit failures are retryable, not bypassed.
+- **Verification:** `do-partition.test.ts` (split/migration scaffolding).
 
-- <https://developers.cloudflare.com/workers/platform/limits/>
-- <https://developers.cloudflare.com/durable-objects/platform/limits/>
+### M4 — HTTP API surface
+- **Scope:** `batchGetItems` / `batchWriteItems` RPC actions in `src/index.ts`: strict valibot schemas
+  (`put`/`delete` variant, no conditions / `clientRequestToken`, count bounds), full-result serializers
+  (`encodeData`, binary-key guard), and `runBatchRpc` mapping `fokos:`-prefixed validation throws to HTTP
+  400 while leaving internal `fokos/` errors as 500.
+- **Files:** `src/index.ts`.
+- **Acceptance:** client validation errors return 400 (not 500); `check`/conditions/`clientRequestToken`
+  rejected; data round-trips via `encodeData`; binary keys fail loud.
+- **Verification:** `test/http-batch.test.ts`.
 
-### Validation
+### M5 — `FokosStd` chunking + bounded retry
+- **Scope:** `FokosStd` composes a `FokosDBAPI` and adds `batchGetAll` / `batchWriteAll`: full-input
+  duplicate rejection **before** chunking; chunk by min(item-count, payload-bytes); bounded
+  exponential-backoff retry (injectable `sleep`/`random`/`isRetryableError`) of unprocessed entries *and*
+  retryable thrown chunk calls; chunk-local→global `inputIndex` re-map on every attempt; honest aggregate
+  meta (cumulative work, final counts, total-visit `partitionMetas`).
+- **Files:** `src/lib/fokos-std.ts`. Shared identity/estimator helpers are imported from
+  `transaction-limits.ts`, not duplicated.
+- **Acceptance:** unbounded input chunks correctly; retries are bounded and return the remaining
+  unprocessed; no cross-chunk duplicate slips through; not exported from the Worker entry (consistent with
+  `FokosDB`).
+- **Verification:** `fokos-std.test.ts`.
 
-Batch validation should share lower-level helpers with transaction validation where useful:
+## 6. Decisions locked
 
-- public key validation;
-- encoded key-size validation;
-- duplicate key detection;
-- payload-byte estimation;
-- max item count checks.
+- **Request shape:** flat per-item list (`items` / `operations`); the chunking convenience form lives in
+  `FokosStd`, not the core wire API.
+- **Op set:** `put` / `delete` only; no conditions; no `clientRequestToken`; not routed through the TC.
+- **Correlation:** `inputIndex`, primary and required; key-echo is for ergonomics only.
+- **No per-applied versions** from the core write result.
+- **Duplicate keys:** rejected at preflight, on encoded `KeyBytes` identity (absent sort key = `[]`).
+- **Atomicity:** none. `transactWriteItems` owns atomic writes; `transactGetItems` owns snapshot reads.
+- **Failure model:** hard input errors throw; runtime per-item failures return retryable `Unprocessed*`.
+- **Guards:** `ensureMigration` before routing + on forwarded children; per-item ownership re-check on the
+  local apply.
+- **Limits:** in `transaction-limits.ts` (below), enforced server-side; DynamoDB 25/100 caps + retry live
+  in `FokosStd`.
+- **Bounding:** real subrequest growth is bounded by item-count caps plus DO-side split/sub-batch guards —
+  **not** by counting `FokosDB`'s initial `pickPartition` roots (`rootTreesN` is user-configurable and
+  split/range expansion happens behind the root). See Appendix B (MF1).
 
-Do not directly reuse `validateTransactWriteOperations` as the batch validator because its public
-errors and constants are transaction-specific. Batch validation should produce batch-specific
-diagnostics.
+## 7. Limits
 
-### Failure taxonomy
+Server-side constants (`src/lib/transaction-limits.ts`), conservative and tunable, chosen under the
+workerd RPC limit rather than relying on the platform as the first line of defense:
 
-Use a discriminated union for per-item retryable failures. At minimum:
+- `MAX_BATCH_GET_ITEMS = 100`, `MAX_BATCH_WRITE_ITEMS = 25` — per-call item caps.
+- `MAX_BATCH_PAYLOAD_BYTES = 4 MB` — per-batch total payload ceiling.
+- `MAX_BATCH_FORWARDED_SUB_BATCH_BYTES = 1 MB` — per-op forwarded ceiling; a single op over this rejects at
+  preflight (deterministic oversize must not masquerade as retryable). The **same estimator** sizes both
+  the preflight check (on raw keys) and the DO-side forwarded chunking (on encoded `KeyBytes`) so the two
+  cannot drift — see Appendix B.
 
-- `pending_lock`;
-- `partition_over_limit`;
-- `transient_error`.
+Re-check current Cloudflare Workers / Durable Objects limits before tuning byte and DO-side constants.
 
-When practical, `pending_lock` should carry the conflicting transaction id, matching the diagnostic
-surface of the existing single-item write path.
+## 8. Failure taxonomy
 
-Hard input errors should throw before work starts, not appear as unprocessed entries.
+Per-item retryable failures are a discriminated union (`src/lib/types.ts`):
 
-### Test checklist
+- `pending_lock` — carries the conflicting transaction id, matching the single-item write diagnostic;
+- `partition_over_limit` — the topology `reject` / retry-later decision, or an `unplaceable` item;
+- `transient_error` — a transient child RPC failure (carries the message).
 
-- public `FokosDB.batchGetItems` preserves input order;
-- public `FokosDB.batchGetItems` returns missing items as `found: false`;
-- public `FokosDB.batchGetItems` reports retryable `UnprocessedKeys` for transient child failures;
-- public `FokosDB.batchGetItems` rejects oversized item count and payload bytes;
-- public `FokosDB.batchWriteItems` rejects empty operations;
-- public `FokosDB.batchWriteItems` rejects duplicate keys, treating absent sort key as the empty key;
-- public `FokosDB.batchWriteItems` rejects unsupported operations and conditions;
-- public `FokosDB.batchWriteItems` rejects oversized item count and payload bytes;
-- public `FokosDB.batchWriteItems` preserves input correlation across routed groups;
-- mixed put/delete writes succeed;
-- pending transaction locks become retryable unprocessed write entries;
-- migration guard is called before routing and in forwarded children;
-- partition over-limit / retry-later errors become retryable unprocessed write entries;
-- successful sibling writes remain visible when another item is unprocessed;
-- HTTP RPC schemas accept the valid request shapes and reject invalid shapes;
-- existing transaction, query, migration, promotion, and split tests still pass.
+Hard input errors throw before work starts; they never appear as unprocessed entries.
 
-### Preparation before implementation
+## 9. Test checklist
 
-Before writing production code:
+- `FokosDB.batchGetItems`: preserves input order; `found: false` for misses; transient child failure →
+  `UnprocessedKeys`; rejects oversized item count / payload.
+- `FokosDB.batchWriteItems`: rejects empty / duplicate (absent sort key = empty key) / unsupported op /
+  conditions / oversized count / oversized single forwarded op; preserves correlation across routed groups;
+  mixed put/delete; pending-lock and over-limit → retryable; siblings stay visible.
+- `PartitionDO`: migration guard called before routing and in forwarded children; single-key item across a
+  completed split forwards and is visible.
+- HTTP: valid shapes accepted, invalid rejected; client validation → 400, internal → 500.
+- `FokosStd`: chunking by count + bytes; cross-chunk duplicate rejection; bounded retry returns remaining
+  unprocessed; chunk-local→global `inputIndex` re-map across retries.
+- Existing transaction, query, migration, promotion, and split tests still pass.
 
-1. Review the existing `queryItems`, transaction, validation, and HTTP RPC shapes and use them as the
-   primary local pattern.
-2. Check the official DynamoDB BatchGetItem / BatchWriteItem docs and record the specific semantics
-   being adopted or intentionally changed.
-3. Confirm the final public result shapes for `BatchGetItemsResult` and `BatchWriteItemsResult`.
-4. Confirm concrete server defaults for max items, max payload bytes, and forwarded sub-batch bytes
-   after checking current Cloudflare limits.
-5. Decide and implement DO-side split/range subrequest bounding. Do not enforce fan-out by counting
-   `FokosDB`'s initial `pickPartition` roots: `rootTreesN` is user-configurable, and split/range
-   expansion happens behind the initial root. M2/M3 should bound real subrequest growth with item-count
-   limits plus DO-side split/sub-batch guards.
-6. Factor the existing single-item local write bodies properly enough that batch writes cannot drift
-   from `putItem` / `deleteItem` behavior.
-7. Extract or design shared validation helpers without changing transaction error strings.
-8. Add tests for validation and result-shape behavior first, then fill in the implementation.
-9. Run the full FokosDB test suite before asking for review.
+## Appendix A — Original GitHub issue draft (historical task anchor)
+
+> Kept as the issue text this work was scoped from. The body above is the authoritative contract.
+
+**Title:** Native non-transactional BatchGet/BatchWrite operations.
+
+**Body:** FokosDB's README lists "Batch item operations (non-transactions)" as a TODO. Add native
+`batchGetItems({ items })` and `batchWriteItems({ operations })` — a DynamoDB-shaped, FokosDB-native
+contract, not full API parity — plus HTTP RPC actions and tests for public/HTTP behavior, validation,
+partial failures, split/migration routing, unprocessed retry, and request limits.
+
+**Non-goals:** full DynamoDB parity; conditional batch writes; atomic batch writes; GSI/index behavior;
+an automatic retry helper outside `FokosStd`.
+
+## Appendix B — Deviations / review fixes
+
+Changes made during dual independent review, after the initial milestone landed:
+
+- **MF1 — fan-out cap removed (M0).** An initial client-side `MAX_BATCH_PARTITION_FANOUT` counted distinct
+  `pickPartition` roots, which is bounded by `rootTreesN` (so a no-op at default and a spurious rejection
+  when `rootTreesN > 10`) and does not reflect server-side split/range expansion. Removed; item-count caps
+  plus M2/M3 DO-side guards are the real subrequest backstop.
+- **MF2 — meta enriched (M0).** `BatchItemsMeta` gained `rowsRead`/`rowsWritten`/`forwardCount`/
+  `partitionsVisited` and the results carry `partitionMetas`, matching `queryItems`/`putItem` rather than a
+  counts-only shape.
+- **Forwarded byte guard + empty-sortKey regression (M3).** A single op over the forwarded ceiling now
+  hard-rejects at preflight. The first fix reused a *validating* estimator on already-encoded keys, which
+  rejected the `[]` absent-sort-key sentinel and double-encoded; split into
+  `estimateBatchWriteForwardedOperationBytes` (raw) and `estimateEncodedBatchWriteForwardedOperationBytes`
+  (encoded), the former defined in terms of the latter so preflight and DO measure the identical bytes.
+- **`migration_in_progress` removed.** The reason was declared but never emitted (migrating-child failures
+  surface as `transient_error`); the dead union member was dropped. Emitting it via a typed migration error
+  is a possible follow-up.
+- **BatchGet fail-loud `inputIndex`.** The echo helpers now throw on an unknown `inputIndex` instead of
+  silently falling back, matching the write path — a missing index means result corruption, not a valid
+  partial failure.
+- **Cleanup.** Removed the `BatchRetryableFailure` identity alias; added a non-version-idempotence comment
+  on the `FokosStd` retry path.
+
+**Known follow-ups (separate tickets, not this work):** extend the `fokos:`→400 mapping to the
+`transactWriteItems` HTTP route; decide `ttlSeconds` honor-or-reject consistently across `putItem` and
+batch (currently forwarded then dropped at the DO, matching pre-existing `putItem` behavior); possible
+extraction of the batch local write body into a participant module.

--- a/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
+++ b/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
@@ -1,12 +1,13 @@
 # Native Batch Item Operations
 
-Status: **proposal / not implemented**. This document captures the GitHub issue draft and the
-implementation contract for native, non-transactional `BatchGet` / `BatchWrite` style operations in
-FokosDB.
+Status: **implemented on `feat/batch-item-ops`**. This document captures the GitHub issue draft and
+the implementation contract for native, non-transactional `BatchGet` / `BatchWrite` style operations
+in FokosDB.
 
 The scope is intentionally narrower than DynamoDB parity and broader than a client-side helper loop.
-The core operations should be native FokosDB RPCs that preserve the existing partition routing,
-migration, split, lock, promotion, and retry behavior.
+The core operations are native FokosDB RPCs that preserve the existing partition routing, migration,
+split, lock, promotion, and retry behavior. `FokosStd` adds optional client-side chunking and bounded
+retry helpers on top of those native operations.
 
 ## Source hierarchy and quality bar
 
@@ -122,14 +123,21 @@ Use the same public key shape as the existing single-item and transaction APIs:
 
 ```ts
 type BatchGetItemsOptions = {
-  items: Array<{ hashKey: string | Uint8Array; sortKey?: string | Uint8Array }>;
+	items: Array<{ hashKey: string | Uint8Array; sortKey?: string | Uint8Array }>;
 };
 
 type BatchWriteItemsOptions = {
-  operations: Array<
-    | { operation: "put"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array; data: string | Uint8Array; ttlSeconds?: number; ttlEpochUTCSeconds?: number }
-    | { operation: "delete"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array }
-  >;
+	operations: Array<
+		| {
+				operation: "put";
+				hashKey: string | Uint8Array;
+				sortKey?: string | Uint8Array;
+				data: string | Uint8Array;
+				ttlSeconds?: number;
+				ttlEpochUTCSeconds?: number;
+		  }
+		| { operation: "delete"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array }
+	>;
 };
 ```
 

--- a/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
+++ b/apps/fokos-svc/docs/agent-plans/native-batch-item-operations.md
@@ -1,0 +1,273 @@
+# Native Batch Item Operations
+
+Status: **proposal / not implemented**. This document captures the GitHub issue draft and the
+implementation contract for native, non-transactional `BatchGet` / `BatchWrite` style operations in
+FokosDB.
+
+The scope is intentionally narrower than DynamoDB parity and broader than a client-side helper loop.
+The core operations should be native FokosDB RPCs that preserve the existing partition routing,
+migration, split, lock, promotion, and retry behavior.
+
+## Source hierarchy and quality bar
+
+Implementation decisions should be resolved in this order:
+
+1. Existing FokosDB behavior and style. Match the public API shape in `FokosDB`, the HTTP RPC shape in
+   `src/index.ts`, the validation style in `transaction-limits.ts`, the split/migration rules in
+   `PartitionDO`, and the level of detail in the existing `queryItems` / `KeyCodec` plans.
+2. Official DynamoDB BatchGetItem / BatchWriteItem documentation, used as the semantic baseline for
+   limits, duplicate-key rejection, non-atomic writes, and `UnprocessedKeys` / `UnprocessedItems`:
+   - <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html>
+   - <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html>
+3. Current Cloudflare Workers / Durable Objects limits, used only to choose safe FokosDB server-side
+   bounds:
+   - <https://developers.cloudflare.com/workers/platform/limits/>
+   - <https://developers.cloudflare.com/durable-objects/platform/limits/>
+
+This work should not be a thin wrapper over existing single-item calls. It should be a native,
+well-factored implementation with tests first around operation semantics, limits, split/migration
+guards, and partial-failure behavior.
+
+## GitHub issue draft
+
+### Title
+
+Native non-transactional BatchGet/BatchWrite operations
+
+### Body
+
+FokosDB's README lists "Batch item operations (non-transactions)" as a TODO. This issue proposes a
+native FokosDB implementation for non-transactional batch reads and writes:
+
+- `batchGetItems({ items })`
+- `batchWriteItems({ operations })`
+
+The goal is a DynamoDB-shaped, FokosDB-native contract rather than full DynamoDB API parity.
+
+#### Scope
+
+- Add public `FokosDB` methods for `batchGetItems` and `batchWriteItems`.
+- Add corresponding HTTP RPC actions.
+- Add a focused operation-semantics note under `docs/agent-plans/`.
+- Add tests for public API behavior, HTTP API behavior, validation, partial failures,
+  split/migration routing, unprocessed retry paths, and request limits.
+
+#### Locked semantics
+
+- Empty batches reject during preflight.
+- Each batch has a hard server-side max item count.
+- Each batch has a hard server-side total payload byte ceiling.
+- Each batch write operation has a hard forwarded sub-batch byte ceiling, so deterministic oversize
+  writes reject during preflight instead of returning retryable `UnprocessedItems`.
+- Server-side split/range fan-out is bounded so one request cannot hit unbounded Durable Object
+  subrequests.
+- `batchWriteItems` supports only `put` and `delete`.
+- `batchWriteItems` has no conditions. Conditional writes remain the job of `transactWriteItems`.
+- Duplicate keys reject the whole batch during preflight.
+- Runtime write failures return retryable `UnprocessedItems`.
+- Runtime read failures return retryable `UnprocessedKeys`.
+- `batchGetItems` is strongly consistent per item, but is not a cross-partition snapshot.
+- Retrying unprocessed puts/deletes is safe but not version-idempotent: last write wins and versions
+  may bump again.
+
+#### Retryable unprocessed cases
+
+Return retryable unprocessed entries for:
+
+- pending transaction locks;
+- migration or split-in-progress guards;
+- partition over-limit / retry-later errors;
+- transient child RPC failures.
+
+#### Implementation constraints
+
+- Do not route batch writes through `TransactionCoordinatorDO`.
+- Do not add SQL migrations.
+- Do not call `validateTransactWriteOperations` directly. Extract shared validation helpers or add
+  batch-specific validation so batch errors are named as batch errors.
+- `batchWriteItems` must call `ensureMigration("batchWriteItems")` before routing, matching the
+  write/transaction migration-guard rule.
+- Forwarded child partitions must re-check migration at their own RPC boundary.
+- Reuse transaction-style multi-item routing via `groupItemsByRouting`, but thread an `inputIndex`
+  through routed work so results can be reconstructed in request order.
+- Reuse the existing single-item local write behavior for pending-lock checks, condition-free
+  upsert/delete, promotion queueing, and split checks.
+
+#### Acceptance criteria
+
+- Empty batches reject.
+- Oversized item count, total payload bytes, or single-operation forwarded bytes are rejected by
+  explicit validation; server-side split/range fan-out is bounded by item-count limits plus DO-side
+  split/sub-batch guards, as defined by the implementation note.
+- Duplicate keys reject.
+- Mixed put/delete batch writes work.
+- Partial write failures return retryable unprocessed items without hiding successful writes.
+- Batch reads preserve input order and report unprocessed keys.
+- Migration tests prove writes do not bypass `ensureMigration`.
+- Existing tests pass.
+
+#### Non-goals
+
+- Full DynamoDB API parity.
+- Conditional batch writes.
+- Atomic batch writes.
+- GSI or index behavior.
+- Automatic retry helper, unless added separately as `FokosStd`.
+
+## Implementation contract
+
+### Public API
+
+Use the same public key shape as the existing single-item and transaction APIs:
+
+```ts
+type BatchGetItemsOptions = {
+  items: Array<{ hashKey: string | Uint8Array; sortKey?: string | Uint8Array }>;
+};
+
+type BatchWriteItemsOptions = {
+  operations: Array<
+    | { operation: "put"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array; data: string | Uint8Array; ttlSeconds?: number; ttlEpochUTCSeconds?: number }
+    | { operation: "delete"; hashKey: string | Uint8Array; sortKey?: string | Uint8Array }
+  >;
+};
+```
+
+The final result types should be decided in the implementation PR, but they must make these
+properties explicit:
+
+- results can be correlated back to the original input position;
+- successful items are not hidden by unrelated failures;
+- retryable failures carry enough information for a caller to retry just those entries;
+- hard validation failures throw before any item is applied.
+
+For `batchWriteItems`, the primary correlation field is `inputIndex`, not key matching. Results may
+also echo keys for ergonomics/debugging, but callers should be able to reconstruct the outcome of the
+request from `inputIndex` alone.
+
+Do not return per-applied item versions from the core `batchWriteItems` result. A single `putItem`
+returns a version, but batch write is a partial-success/retry API: it should report processed versus
+unprocessed entries, not become a read-after-write result API. Callers that need versions can read the
+items they care about after the batch completes.
+
+### Batch write execution
+
+`batchWriteItems` is non-atomic across the whole request and non-atomic within one partition. This is
+intentional. Callers that need atomicity must use `transactWriteItems`.
+
+The write path should compose existing behavior rather than bypass it:
+
+1. Validate and encode public keys at the `FokosDB` boundary.
+2. Reject empty batches, duplicate keys, unsupported operations, invalid keys, and oversized payloads
+   before any write is attempted.
+3. Pick initial partitions from the client-side topology.
+4. At the `PartitionDO` RPC boundary, call `ensureMigration("batchWriteItems")` before routing.
+5. Use `groupItemsByRouting` to split items into local and forwarded groups.
+6. Keep `inputIndex` on every routed item so destination grouping does not destroy request order.
+7. Forward child groups with `Promise.allSettled`.
+8. Apply local items independently using the same semantics as single-item `putItem` and `deleteItem`:
+   pending-lock check, upsert/delete, promotion queueing, and split checks.
+9. Return successes and retryable unprocessed entries without converting sibling successes into
+   failures.
+
+The local write implementation should factor the existing single-item local bodies instead of copying
+large blocks. If factoring is too invasive, copying the smallest necessary block is acceptable for the
+first PR, but the behavior must stay aligned with single-item writes.
+
+### Batch get execution
+
+`batchGetItems` is strongly consistent per key. It is not a global point-in-time snapshot across
+partitions; consistent multi-key snapshots remain the job of `transactGetItems`.
+
+Reads should preserve input order and return `found: false` for missing items. Runtime read failures
+that are safe to retry should be returned as `UnprocessedKeys`.
+
+For migration, reads should keep the same behavior as `getItem`: a migrating child may read directly
+from its parent rather than throwing.
+
+### Limits
+
+The implementation must define explicit server-side limits:
+
+- max items per batch;
+- max encoded payload bytes per batch;
+- max server-side split/range fan-out or forwarded sub-batches per batch;
+- max forwarded sub-batch payload bytes.
+
+Do not rely on Cloudflare platform limits as the first line of defense. Pick conservative defaults
+below the current Workers / Durable Objects limits, document the rationale in code, and keep the
+constants easy to tune.
+
+At implementation time, re-check the current official Cloudflare Workers limits and Durable Objects
+limits before choosing byte and DO-side sub-batch constants:
+
+- <https://developers.cloudflare.com/workers/platform/limits/>
+- <https://developers.cloudflare.com/durable-objects/platform/limits/>
+
+### Validation
+
+Batch validation should share lower-level helpers with transaction validation where useful:
+
+- public key validation;
+- encoded key-size validation;
+- duplicate key detection;
+- payload-byte estimation;
+- max item count checks.
+
+Do not directly reuse `validateTransactWriteOperations` as the batch validator because its public
+errors and constants are transaction-specific. Batch validation should produce batch-specific
+diagnostics.
+
+### Failure taxonomy
+
+Use a discriminated union for per-item retryable failures. At minimum:
+
+- `pending_lock`;
+- `migration_in_progress`;
+- `partition_over_limit`;
+- `transient_error`.
+
+When practical, `pending_lock` should carry the conflicting transaction id, matching the diagnostic
+surface of the existing single-item write path.
+
+Hard input errors should throw before work starts, not appear as unprocessed entries.
+
+### Test checklist
+
+- public `FokosDB.batchGetItems` preserves input order;
+- public `FokosDB.batchGetItems` returns missing items as `found: false`;
+- public `FokosDB.batchGetItems` reports retryable `UnprocessedKeys` for transient child failures;
+- public `FokosDB.batchGetItems` rejects oversized item count and payload bytes;
+- public `FokosDB.batchWriteItems` rejects empty operations;
+- public `FokosDB.batchWriteItems` rejects duplicate keys, treating absent sort key as the empty key;
+- public `FokosDB.batchWriteItems` rejects unsupported operations and conditions;
+- public `FokosDB.batchWriteItems` rejects oversized item count and payload bytes;
+- public `FokosDB.batchWriteItems` preserves input correlation across routed groups;
+- mixed put/delete writes succeed;
+- pending transaction locks become retryable unprocessed write entries;
+- migration guard is called before routing and in forwarded children;
+- partition over-limit / retry-later errors become retryable unprocessed write entries;
+- successful sibling writes remain visible when another item is unprocessed;
+- HTTP RPC schemas accept the valid request shapes and reject invalid shapes;
+- existing transaction, query, migration, promotion, and split tests still pass.
+
+### Preparation before implementation
+
+Before writing production code:
+
+1. Review the existing `queryItems`, transaction, validation, and HTTP RPC shapes and use them as the
+   primary local pattern.
+2. Check the official DynamoDB BatchGetItem / BatchWriteItem docs and record the specific semantics
+   being adopted or intentionally changed.
+3. Confirm the final public result shapes for `BatchGetItemsResult` and `BatchWriteItemsResult`.
+4. Confirm concrete server defaults for max items, max payload bytes, and forwarded sub-batch bytes
+   after checking current Cloudflare limits.
+5. Decide and implement DO-side split/range subrequest bounding. Do not enforce fan-out by counting
+   `FokosDB`'s initial `pickPartition` roots: `rootTreesN` is user-configurable, and split/range
+   expansion happens behind the initial root. M2/M3 should bound real subrequest growth with item-count
+   limits plus DO-side split/sub-batch guards.
+6. Factor the existing single-item local write bodies properly enough that batch writes cannot drift
+   from `putItem` / `deleteItem` behavior.
+7. Extract or design shared validation helpers without changing transaction error strings.
+8. Add tests for validation and result-shape behavior first, then fill in the implementation.
+9. Run the full FokosDB test suite before asking for review.

--- a/apps/fokos-svc/src/index.ts
+++ b/apps/fokos-svc/src/index.ts
@@ -5,7 +5,8 @@ import * as v from "valibot";
 import { FokosDB } from "./lib/db.js";
 import { PartitionContextCreator, type SplitConditions } from "./lib/partition-topology/partition-context.js";
 import { PartitionTopologyRouterImpl } from "./lib/partition-topology/router.js";
-import type { GetItemResult, InitiateReadResponse, QueryItemsResult } from "./lib/types.js";
+import { MAX_BATCH_GET_ITEMS, MAX_BATCH_WRITE_ITEMS } from "./lib/transaction-limits.js";
+import type { BatchGetItemsResult, BatchWriteItemsResult, GetItemResult, InitiateReadResponse, QueryItemsResult } from "./lib/types.js";
 
 export { PartitionDO } from "./lib/do-partition.js";
 export { TransactionCoordinatorDO } from "./lib/do-transaction-coordinator.js";
@@ -78,6 +79,46 @@ const TransactWriteItemsBodySchema = v.object({
 
 const TransactGetItemsBodySchema = v.object({
 	items: v.array(v.object({ hashKey: v.string(), sortKey: v.optional(v.string()) })),
+	partitionOptions: PartitionOptionsSchema,
+});
+
+const BatchGetItemsBodySchema = v.strictObject({
+	items: v.pipe(
+		v.array(v.strictObject({ hashKey: v.string(), sortKey: v.optional(v.string()) })),
+		v.minLength(1, "fokos: batchGetItems requires at least 1 item"),
+		v.maxLength(MAX_BATCH_GET_ITEMS, `fokos: batchGetItems supports at most ${MAX_BATCH_GET_ITEMS} items`),
+	),
+	partitionOptions: PartitionOptionsSchema,
+});
+
+const BatchWriteItemsBodySchema = v.strictObject({
+	operations: v.pipe(
+		v.array(
+			v.variant("operation", [
+				v.pipe(
+					v.strictObject({
+						operation: v.literal("put"),
+						hashKey: v.string(),
+						sortKey: v.optional(v.string()),
+						ttlSeconds: v.optional(v.number()),
+						ttlEpochUTCSeconds: v.optional(v.number()),
+						data: v.string(),
+					}),
+					v.check(
+						(input) => !(input.ttlSeconds !== undefined && input.ttlEpochUTCSeconds !== undefined),
+						"Only one of ttlSeconds or ttlEpochUTCSeconds may be provided, not both",
+					),
+				),
+				v.strictObject({
+					operation: v.literal("delete"),
+					hashKey: v.string(),
+					sortKey: v.optional(v.string()),
+				}),
+			]),
+		),
+		v.minLength(1, "fokos: batchWriteItems requires at least 1 item"),
+		v.maxLength(MAX_BATCH_WRITE_ITEMS, `fokos: batchWriteItems supports at most ${MAX_BATCH_WRITE_ITEMS} items`),
+	),
 	partitionOptions: PartitionOptionsSchema,
 });
 
@@ -164,6 +205,57 @@ function serializeQueryItemsResult(result: QueryItemsResult) {
 			return { ...rest, hashKey, sortKey, ...encodeData(data) };
 		}),
 	};
+}
+
+function assertStringKeysForHttp(
+	rpcAction: "batchGetItems" | "batchWriteItems",
+	item: { hashKey: string | Uint8Array; sortKey?: string | Uint8Array },
+) {
+	if (item.hashKey instanceof Uint8Array || item.sortKey instanceof Uint8Array) {
+		throw new HTTPException(500, { message: `fokos/${rpcAction}: binary keys are not supported over the HTTP API` });
+	}
+}
+
+function serializeBatchGetItemsResult(result: BatchGetItemsResult) {
+	return {
+		...result,
+		items: result.items.map((item) => {
+			assertStringKeysForHttp("batchGetItems", item.item);
+			if (!item.found) return item;
+			const { data, ...itemRest } = item.item;
+			return { ...item, item: { ...itemRest, ...encodeData(data) } };
+		}),
+		unprocessedKeys: result.unprocessedKeys.map((item) => {
+			assertStringKeysForHttp("batchGetItems", item.item);
+			return item;
+		}),
+	};
+}
+
+function serializeBatchWriteItemsResult(result: BatchWriteItemsResult) {
+	return {
+		...result,
+		processedItems: result.processedItems.map((item) => {
+			assertStringKeysForHttp("batchWriteItems", item.item);
+			return item;
+		}),
+		unprocessedItems: result.unprocessedItems.map((item) => {
+			assertStringKeysForHttp("batchWriteItems", item.item);
+			return item;
+		}),
+	};
+}
+
+async function runBatchRpc<T>(fn: () => Promise<T>): Promise<T> {
+	try {
+		return await fn();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (message.startsWith("fokos:")) {
+			throw new HTTPException(400, { message });
+		}
+		throw error;
+	}
 }
 
 function serializeTransactGetItemsResult(result: InitiateReadResponse) {
@@ -289,6 +381,18 @@ api.post("/rpc/:tableName/:rpcAction", async (c) => {
 			const result = await makeFokosDB(c.env, tableName, partitionOptions).getItem(opts);
 			c.set("dbItemMeta", result.meta);
 			return c.json(serializeGetItemResult(result));
+		}
+		case "batchGetItems": {
+			const { partitionOptions, ...opts } = parseBody(BatchGetItemsBodySchema);
+			const result = await runBatchRpc(() => makeFokosDB(c.env, tableName, partitionOptions).batchGetItems(opts));
+			c.set("dbItemMeta", result.meta);
+			return c.json(serializeBatchGetItemsResult(result));
+		}
+		case "batchWriteItems": {
+			const { partitionOptions, ...opts } = parseBody(BatchWriteItemsBodySchema);
+			const result = await runBatchRpc(() => makeFokosDB(c.env, tableName, partitionOptions).batchWriteItems(opts));
+			c.set("dbItemMeta", result.meta);
+			return c.json(serializeBatchWriteItemsResult(result));
 		}
 		case "deleteItem": {
 			const { partitionOptions, ...opts } = parseBody(DeleteItemBodySchema);

--- a/apps/fokos-svc/src/lib/batch-types.test.ts
+++ b/apps/fokos-svc/src/lib/batch-types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { BatchGetItemsResult, BatchWriteItemsResult } from "./types.js";
+
+const meta = {
+	requestedCount: 2,
+	processedCount: 1,
+	unprocessedCount: 1,
+	rowsRead: 3,
+	rowsWritten: 4,
+	forwardCount: 5,
+	partitionsVisited: 1,
+};
+
+const partitionMeta = {
+	rowsRead: 3,
+	rowsWritten: 4,
+	databaseSize: 1024,
+	servedByActorId: "actor-id",
+	servedByActorName: "actor-name",
+	servedByPartitionId: "partition-id",
+	forwardCount: 5,
+	hashDepth: 0,
+};
+
+describe("batch item public result shapes", () => {
+	it("correlates batchGet processed and unprocessed entries by inputIndex", () => {
+		const result = {
+			items: [{ inputIndex: 1, found: false, item: { hashKey: "missing" } }],
+			unprocessedKeys: [{ inputIndex: 0, item: { hashKey: "retry" }, reason: { type: "transient_error" } }],
+			meta,
+			partitionMetas: [partitionMeta],
+		} satisfies BatchGetItemsResult;
+
+		type ProcessedHasInputIndex = "inputIndex" extends keyof BatchGetItemsResult["items"][number] ? true : false;
+		type UnprocessedHasInputIndex = "inputIndex" extends keyof BatchGetItemsResult["unprocessedKeys"][number] ? true : false;
+		type MetaHasPartitionsVisited = "partitionsVisited" extends keyof BatchGetItemsResult["meta"] ? true : false;
+		type MetaHasPartitionCount = "partitionCount" extends keyof BatchGetItemsResult["meta"] ? true : false;
+		const processedHasInputIndex: ProcessedHasInputIndex = true;
+		const unprocessedHasInputIndex: UnprocessedHasInputIndex = true;
+		const metaHasPartitionsVisited: MetaHasPartitionsVisited = true;
+		const metaHasPartitionCount: MetaHasPartitionCount = false;
+
+		expect(processedHasInputIndex).toBe(true);
+		expect(unprocessedHasInputIndex).toBe(true);
+		expect(metaHasPartitionsVisited).toBe(true);
+		expect(metaHasPartitionCount).toBe(false);
+		expect(result.items[0].inputIndex).toBe(1);
+		expect(result.unprocessedKeys[0].inputIndex).toBe(0);
+		expect(result.meta.partitionsVisited).toBe(1);
+		expect(result.partitionMetas).toEqual([partitionMeta]);
+	});
+
+	it("correlates batchWrite entries by inputIndex and omits per-applied versions", () => {
+		const result = {
+			processedItems: [{ inputIndex: 1, operation: "put", item: { hashKey: "written" } }],
+			unprocessedItems: [{ inputIndex: 0, operation: "delete", item: { hashKey: "retry" }, reason: { type: "pending_lock" } }],
+			meta,
+			partitionMetas: [partitionMeta],
+		} satisfies BatchWriteItemsResult;
+
+		type ProcessedHasInputIndex = "inputIndex" extends keyof BatchWriteItemsResult["processedItems"][number] ? true : false;
+		type UnprocessedHasInputIndex = "inputIndex" extends keyof BatchWriteItemsResult["unprocessedItems"][number] ? true : false;
+		type ProcessedHasVersion = "version" extends keyof BatchWriteItemsResult["processedItems"][number] ? true : false;
+		type MetaHasPartitionsVisited = "partitionsVisited" extends keyof BatchWriteItemsResult["meta"] ? true : false;
+		type MetaHasPartitionCount = "partitionCount" extends keyof BatchWriteItemsResult["meta"] ? true : false;
+		const processedHasInputIndex: ProcessedHasInputIndex = true;
+		const unprocessedHasInputIndex: UnprocessedHasInputIndex = true;
+		const processedHasVersion: ProcessedHasVersion = false;
+		const metaHasPartitionsVisited: MetaHasPartitionsVisited = true;
+		const metaHasPartitionCount: MetaHasPartitionCount = false;
+
+		expect(processedHasInputIndex).toBe(true);
+		expect(unprocessedHasInputIndex).toBe(true);
+		expect(processedHasVersion).toBe(false);
+		expect(metaHasPartitionsVisited).toBe(true);
+		expect(metaHasPartitionCount).toBe(false);
+		expect(result.processedItems[0].inputIndex).toBe(1);
+		expect("version" in result.processedItems[0]).toBe(false);
+		expect(result.meta.partitionsVisited).toBe(1);
+		expect(result.partitionMetas).toEqual([partitionMeta]);
+	});
+});

--- a/apps/fokos-svc/src/lib/batch-types.ts
+++ b/apps/fokos-svc/src/lib/batch-types.ts
@@ -1,7 +1,6 @@
 import type {
 	BatchGetProcessedItem,
 	BatchGetUnprocessedKey,
-	BatchRetryableFailureReason,
 	BatchWriteProcessedItem,
 	BatchWriteUnprocessedItem,
 	OperationMetrics,
@@ -53,5 +52,3 @@ export type BatchWriteItemsRpcResult = {
 	meta: OperationMetrics & PartitionInfo;
 	partitionMetas: Array<OperationMetrics & PartitionInfo>;
 };
-
-export type BatchRetryableFailure = BatchRetryableFailureReason;

--- a/apps/fokos-svc/src/lib/batch-types.ts
+++ b/apps/fokos-svc/src/lib/batch-types.ts
@@ -1,0 +1,57 @@
+import type {
+	BatchGetProcessedItem,
+	BatchGetUnprocessedKey,
+	BatchRetryableFailureReason,
+	BatchWriteProcessedItem,
+	BatchWriteUnprocessedItem,
+	OperationMetrics,
+	PartitionInfo,
+} from "./types.js";
+import type { KeyBytes } from "./partition-topology/key-codec.js";
+
+export type BatchGetRpcItem = {
+	inputIndex: number;
+	hashKey: KeyBytes;
+	sortKey: KeyBytes;
+};
+
+export type BatchGetItemsRpcRequest = {
+	items: BatchGetRpcItem[];
+};
+
+export type BatchGetItemsRpcResult = {
+	items: BatchGetProcessedItem[];
+	unprocessedKeys: BatchGetUnprocessedKey[];
+	meta: OperationMetrics & PartitionInfo;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
+
+export type BatchWriteRpcOperation =
+	| {
+			inputIndex: number;
+			operation: "put";
+			hashKey: KeyBytes;
+			sortKey: KeyBytes;
+			data: Uint8Array | string;
+			ttlSeconds?: number;
+			ttlEpochUTCSeconds?: number;
+	  }
+	| {
+			inputIndex: number;
+			operation: "delete";
+			hashKey: KeyBytes;
+			sortKey: KeyBytes;
+	  };
+
+export type BatchWriteItemsRpcRequest = {
+	operations: BatchWriteRpcOperation[];
+};
+
+export type BatchWriteItemsRpcResult = {
+	processedItems: BatchWriteProcessedItem[];
+	unprocessedItems: BatchWriteUnprocessedItem[];
+	meta: OperationMetrics & PartitionInfo;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
+
+export type BatchRetryableFailure = BatchRetryableFailureReason;

--- a/apps/fokos-svc/src/lib/db.test.ts
+++ b/apps/fokos-svc/src/lib/db.test.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-import { FokosDB } from "./db.js";
+import { FokosDB, type FokosDBOptions } from "./db.js";
+import type { BatchGetItemsRpcResult } from "./batch-types.js";
 import { MAX_BATCH_FORWARDED_SUB_BATCH_BYTES, MAX_BATCH_GET_ITEMS, MAX_BATCH_WRITE_ITEMS } from "./transaction-limits.js";
 import { KeyCodec } from "./partition-topology/key-codec.js";
 import { PartitionContextCreator } from "./partition-topology/partition-context.js";
@@ -46,6 +47,32 @@ describe("FokosDB batch item operations", () => {
 		expect(result.meta.rowsRead).toBe(2);
 		expect(result.partitionMetas).toHaveLength(1);
 		expect(result.partitionMetas[0]).toMatchObject({ rowsRead: 2, rowsWritten: 0, forwardCount: 0 });
+	});
+
+	it("batchGetItems fails loudly when an RPC returns an unknown processed inputIndex", async () => {
+		const db = makeDBReturningBatchGet({
+			items: [{ inputIndex: 1, found: false, item: { hashKey: "corrupt" } }],
+			unprocessedKeys: [],
+			meta: batchRpcMeta(),
+			partitionMetas: [],
+		});
+
+		await expect(db.batchGetItems({ items: [{ hashKey: "only" }] })).rejects.toThrow(
+			/fokos\/batchGetItems: missing original item for inputIndex 1/,
+		);
+	});
+
+	it("batchGetItems fails loudly when an RPC returns an unknown unprocessed inputIndex", async () => {
+		const db = makeDBReturningBatchGet({
+			items: [],
+			unprocessedKeys: [{ inputIndex: 1, item: { hashKey: "corrupt" }, reason: { type: "transient_error" } }],
+			meta: batchRpcMeta(),
+			partitionMetas: [],
+		});
+
+		await expect(db.batchGetItems({ items: [{ hashKey: "only" }] })).rejects.toThrow(
+			/fokos\/batchGetItems: missing original item for inputIndex 1/,
+		);
 	});
 
 	it("rejects invalid batchWriteItems input before the native routing boundary", async () => {
@@ -513,6 +540,56 @@ function makeDBHarness(rootTreesN = 1) {
 
 function makeDB(rootTreesN = 1) {
 	return makeDBHarness(rootTreesN).db;
+}
+
+function makeDBReturningBatchGet(result: BatchGetItemsRpcResult) {
+	const tableName = `test.${crypto.randomUUID()}`;
+	const base = PartitionContextCreator.create({
+		ns: "PARTITION_DO",
+		tableName,
+		rootTreesN: 1,
+		hashSplitN: 2,
+		rangeSplitN: 2,
+		hashSplitConditions: { maxSizeMb: 500 },
+		rangeSplitConditions: { maxSizeMb: 500 },
+	});
+	const doName = `${tableName}.fake`;
+	const doId = env.PARTITION_DO.idFromName(doName);
+	const partitionContext = {
+		...base,
+		doName,
+		primaryDoIdStr: doId.toString(),
+		partitionId: "00",
+	};
+	const topology: FokosDBOptions["topology"] = {
+		partitionContext: () => base,
+		pickPartition: () => ({ doId, partitionContext }),
+		rootPartitionContexts: () => [partitionContext],
+		traverseForDestroy: async () => {},
+	};
+	const ns = {
+		get: () => ({
+			batchGetItems: async () => result,
+		}),
+	} as unknown as FokosDBOptions["ns"];
+	return new FokosDB({
+		ns,
+		topology,
+		transactionCoordinatorNs: env.TRANSACTION_COORDINATOR_DO,
+	});
+}
+
+function batchRpcMeta(): BatchGetItemsRpcResult["meta"] {
+	return {
+		rowsRead: 0,
+		rowsWritten: 0,
+		databaseSize: 0,
+		servedByActorId: "actor-id",
+		servedByActorName: "actor-name",
+		servedByPartitionId: "partition-id",
+		forwardCount: 0,
+		hashDepth: 0,
+	};
 }
 
 function sksOf(res: { items: Array<{ sortKey?: string | Uint8Array }> }) {

--- a/apps/fokos-svc/src/lib/db.test.ts
+++ b/apps/fokos-svc/src/lib/db.test.ts
@@ -1,8 +1,224 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import { FokosDB } from "./db.js";
+import { MAX_BATCH_FORWARDED_SUB_BATCH_BYTES, MAX_BATCH_GET_ITEMS, MAX_BATCH_WRITE_ITEMS } from "./transaction-limits.js";
+import { KeyCodec } from "./partition-topology/key-codec.js";
 import { PartitionContextCreator } from "./partition-topology/partition-context.js";
+import { hashRootIndex } from "./partition-topology/partition-id.js";
 import { PartitionTopologyRouterImpl } from "./partition-topology/router.js";
+
+describe("FokosDB batch item operations", () => {
+	it("rejects invalid batchGetItems input before the native routing boundary", async () => {
+		const db = makeDB();
+		await expect(db.batchGetItems({ items: [] })).rejects.toThrow(/batchGetItems requires at least 1 item/);
+		await expect(
+			db.batchGetItems({ items: Array.from({ length: MAX_BATCH_GET_ITEMS + 1 }, (_, i) => ({ hashKey: `hk-${i}` })) }),
+		).rejects.toThrow(/batchGetItems supports at most 100 items/);
+		await expect(db.batchGetItems({ items: [{ hashKey: "a" }, { hashKey: "a" }] })).rejects.toThrow(/batchGetItems duplicate key/);
+	});
+
+	it("batchGetItems returns found and missing items in request order with inputIndex correlation", async () => {
+		const db = makeDB();
+		await db.putItem({ hashKey: "a", sortKey: "1", data: "a1" });
+		await db.putItem({ hashKey: "b", data: "b0" });
+
+		const result = await db.batchGetItems({
+			items: [{ hashKey: "missing" }, { hashKey: "a", sortKey: "1" }, { hashKey: "b" }],
+		});
+
+		expect(result.unprocessedKeys).toEqual([]);
+		expect(result.items.map((item) => item.inputIndex)).toEqual([0, 1, 2]);
+		expect(result.items[0]).toMatchObject({ inputIndex: 0, found: false, item: { hashKey: "missing", sortKey: undefined } });
+		expect(result.items[1]).toMatchObject({ inputIndex: 1, found: true, item: { hashKey: "a", sortKey: "1", data: "a1", version: 1 } });
+		expect(result.items[2]).toMatchObject({
+			inputIndex: 2,
+			found: true,
+			item: { hashKey: "b", sortKey: undefined, data: "b0", version: 1 },
+		});
+		expect(result.meta).toMatchObject({
+			requestedCount: 3,
+			processedCount: 3,
+			unprocessedCount: 0,
+			rowsWritten: 0,
+			forwardCount: 0,
+			partitionsVisited: 1,
+		});
+		expect(result.meta.rowsRead).toBe(2);
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0]).toMatchObject({ rowsRead: 2, rowsWritten: 0, forwardCount: 0 });
+	});
+
+	it("rejects invalid batchWriteItems input before the native routing boundary", async () => {
+		const db = makeDB();
+		await expect(db.batchWriteItems({ operations: [] })).rejects.toThrow(/batchWriteItems requires at least 1 item/);
+		await expect(
+			db.batchWriteItems({
+				operations: Array.from({ length: MAX_BATCH_WRITE_ITEMS + 1 }, (_, i) => ({ operation: "put", hashKey: `hk-${i}`, data: "x" })),
+			}),
+		).rejects.toThrow(/batchWriteItems supports at most 25 items/);
+		await expect(
+			db.batchWriteItems({
+				operations: [
+					{ operation: "put", hashKey: "a", data: "x" },
+					{ operation: "delete", hashKey: "a" },
+				],
+			}),
+		).rejects.toThrow(/batchWriteItems duplicate key/);
+		await expect(db.batchWriteItems({ operations: [{ operation: "check", hashKey: "a" }] as never })).rejects.toThrow(
+			/operation must be "put" or "delete"/,
+		);
+		await expect(
+			db.batchWriteItems({ operations: [{ operation: "put", hashKey: "a", data: "x", conditions: [{ type: "item_exists" }] }] as never }),
+		).rejects.toThrow(/does not support conditions/);
+		await expect(
+			db.batchWriteItems({
+				operations: Array.from({ length: 5 }, (_, i) => ({
+					operation: "put",
+					hashKey: `payload-too-large-${i}`,
+					data: new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES - 128),
+				})),
+			}),
+		).rejects.toThrow(/batchWriteItems total payload exceeds 4 MB/);
+		await expect(
+			db.batchWriteItems({
+				operations: [{ operation: "put", hashKey: "forwarded-too-large", data: new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES + 1) }],
+			}),
+		).rejects.toThrow(/batchWriteItems operation payload exceeds 1 MB forwarded sub-batch limit/);
+	});
+
+	it("batchWriteItems applies mixed put/delete on a single root and omits per-item versions", async () => {
+		const db = makeDB();
+		await db.putItem({ hashKey: "existing", data: "old" });
+
+		const result = await db.batchWriteItems({
+			operations: [
+				{ operation: "put", hashKey: "created", data: "new" },
+				{ operation: "delete", hashKey: "existing" },
+			],
+		});
+
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.processedItems).toEqual([
+			{ inputIndex: 0, operation: "put", item: { hashKey: "created", sortKey: undefined } },
+			{ inputIndex: 1, operation: "delete", item: { hashKey: "existing", sortKey: undefined } },
+		]);
+		expect("version" in result.processedItems[0]).toBe(false);
+		await expect(db.getItem({ hashKey: "created" })).resolves.toMatchObject({ found: true, item: { data: "new" } });
+		await expect(db.getItem({ hashKey: "existing" })).resolves.toMatchObject({ found: false });
+		expect(result.meta).toMatchObject({
+			requestedCount: 2,
+			processedCount: 2,
+			unprocessedCount: 0,
+			forwardCount: 0,
+			partitionsVisited: 1,
+		});
+		expect(result.meta.rowsWritten).toBeGreaterThan(0);
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0]).toMatchObject({ forwardCount: 0 });
+		expect(result.partitionMetas[0].rowsWritten).toBeGreaterThan(0);
+	});
+
+	it("batchWriteItems preserves sibling successes when one local item has a pending transaction lock", async () => {
+		const { db, topology } = makeDBHarness();
+		const lockedHashKey = KeyCodec.encode("locked");
+		const lockedSortKey = KeyCodec.encodeOptional(undefined);
+		const { doId, partitionContext } = topology.pickPartition(lockedHashKey, lockedSortKey);
+		const stub = env.PARTITION_DO.get(doId);
+		const txId = crypto.randomUUID();
+		const prepareResult = await stub.prepare(partitionContext, {
+			transactionId: txId,
+			transactionTimestamp: Date.now(),
+			coordinatorDoId: env.TRANSACTION_COORDINATOR_DO.newUniqueId().toString(),
+			items: [{ hashKey: lockedHashKey, sortKey: lockedSortKey, operation: "put", data: "pending" }],
+		});
+		expect(prepareResult).toEqual({ outcome: "accepted" });
+
+		const result = await db.batchWriteItems({
+			operations: [
+				{ operation: "put", hashKey: "locked", data: "blocked" },
+				{ operation: "put", hashKey: "unlocked", data: "visible" },
+			],
+		});
+
+		expect(result.processedItems).toEqual([{ inputIndex: 1, operation: "put", item: { hashKey: "unlocked", sortKey: undefined } }]);
+		expect(result.unprocessedItems).toEqual([
+			{
+				inputIndex: 0,
+				operation: "put",
+				item: { hashKey: "locked", sortKey: undefined },
+				reason: { type: "pending_lock", conflictingTransactionId: txId },
+			},
+		]);
+		await expect(db.getItem({ hashKey: "unlocked" })).resolves.toMatchObject({ found: true, item: { data: "visible" } });
+		await expect(db.getItem({ hashKey: "locked" })).resolves.toMatchObject({ found: false });
+		expect(result.meta).toMatchObject({
+			requestedCount: 2,
+			processedCount: 1,
+			unprocessedCount: 1,
+			forwardCount: 0,
+			partitionsVisited: 1,
+		});
+		expect(result.meta.rowsWritten).toBeGreaterThan(0);
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0].rowsWritten).toBeGreaterThan(0);
+
+		await stub.cancel(partitionContext, { transactionId: txId });
+		const retryResult = await db.batchWriteItems({ operations: [{ operation: "put", hashKey: "locked", data: "blocked" }] });
+		expect(retryResult.unprocessedItems).toEqual([]);
+		expect(retryResult.processedItems).toEqual([{ inputIndex: 0, operation: "put", item: { hashKey: "locked", sortKey: undefined } }]);
+		await expect(db.getItem({ hashKey: "locked" })).resolves.toMatchObject({ found: true, item: { data: "blocked" } });
+	});
+
+	it("batchGetItems succeeds across more than ten initial roots and aggregates partition metadata", async () => {
+		const rootTreesN = 64;
+		const db = makeDB(rootTreesN);
+		const hashKeys = keysForDistinctRootPartitions(11, rootTreesN);
+		for (const hashKey of hashKeys) {
+			await db.putItem({ hashKey, data: `data-${hashKey}` });
+		}
+
+		const result = await db.batchGetItems({ items: hashKeys.map((hashKey) => ({ hashKey })) });
+
+		expect(result.unprocessedKeys).toEqual([]);
+		expect(result.items.map((item) => item.inputIndex)).toEqual(hashKeys.map((_, index) => index));
+		expect(result.items).toHaveLength(hashKeys.length);
+		expect(result.meta).toMatchObject({
+			requestedCount: hashKeys.length,
+			processedCount: hashKeys.length,
+			unprocessedCount: 0,
+			rowsRead: hashKeys.length,
+			rowsWritten: 0,
+			forwardCount: 0,
+			partitionsVisited: hashKeys.length,
+		});
+		expect(result.partitionMetas).toHaveLength(hashKeys.length);
+		expect(result.partitionMetas.reduce((sum, meta) => sum + meta.rowsRead, 0)).toBe(hashKeys.length);
+	});
+
+	it("batchWriteItems succeeds across more than ten initial roots without a client fan-out cap", async () => {
+		const rootTreesN = 64;
+		const db = makeDB(rootTreesN);
+		const operations = keysForDistinctRootPartitions(11, rootTreesN).map((hashKey) => ({
+			operation: "put" as const,
+			hashKey,
+			data: "x",
+		}));
+
+		const result = await db.batchWriteItems({ operations });
+
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.processedItems.map((item) => item.inputIndex)).toEqual(operations.map((_, index) => index));
+		expect(result.meta).toMatchObject({
+			requestedCount: operations.length,
+			processedCount: operations.length,
+			unprocessedCount: 0,
+			forwardCount: 0,
+			partitionsVisited: operations.length,
+		});
+		expect(result.meta.rowsWritten).toBeGreaterThanOrEqual(operations.length);
+		expect(result.partitionMetas).toHaveLength(operations.length);
+	});
+});
 
 describe("FokosDB.queryItems — multi sub-query fan-out", () => {
 	it("groups results per sub-query in request order, sk-ordered within each group", async () => {
@@ -275,24 +491,43 @@ describe("FokosDB.queryItems — sort-key condition operators", () => {
 // Builds a FokosDB over a fresh, isolated table. Generous split thresholds keep every key on a
 // single root partition so these tests exercise FokosDB.queryItems' cross-sub-query fan-out and
 // pagination, not the DO-level range-tree walk (covered in do-partition.test.ts).
-function makeDB() {
+function makeDBHarness(rootTreesN = 1) {
 	const tableName = `test.${crypto.randomUUID()}`;
 	const base = PartitionContextCreator.create({
 		ns: "PARTITION_DO",
 		tableName,
-		rootTreesN: 1,
+		rootTreesN,
 		hashSplitN: 2,
 		rangeSplitN: 2,
 		hashSplitConditions: { maxSizeMb: 500 },
 		rangeSplitConditions: { maxSizeMb: 500 },
 	});
-	return new FokosDB({
+	const topology = new PartitionTopologyRouterImpl(base);
+	const db = new FokosDB({
 		ns: env.PARTITION_DO,
-		topology: new PartitionTopologyRouterImpl(base),
+		topology,
 		transactionCoordinatorNs: env.TRANSACTION_COORDINATOR_DO,
 	});
+	return { db, topology };
+}
+
+function makeDB(rootTreesN = 1) {
+	return makeDBHarness(rootTreesN).db;
 }
 
 function sksOf(res: { items: Array<{ sortKey?: string | Uint8Array }> }) {
 	return res.items.map((i) => i.sortKey);
+}
+
+function keysForDistinctRootPartitions(count: number, rootTreesN: number): string[] {
+	const keysByRoot = new Map<number, string>();
+	for (let i = 0; keysByRoot.size < count && i < 10_000; i++) {
+		const hashKey = `batch-fanout-${i}`;
+		const rootIdx = hashRootIndex(KeyCodec.encode(hashKey), rootTreesN);
+		if (!keysByRoot.has(rootIdx)) {
+			keysByRoot.set(rootIdx, hashKey);
+		}
+	}
+	expect(keysByRoot.size).toBe(count);
+	return [...keysByRoot.values()];
 }

--- a/apps/fokos-svc/src/lib/db.ts
+++ b/apps/fokos-svc/src/lib/db.ts
@@ -226,7 +226,9 @@ export class FokosDB {
 
 	private echoBatchGetOriginalKey(item: BatchGetProcessedItem, originalItems: Map<number, ItemKey>): BatchGetProcessedItem {
 		const originalItem = originalItems.get(item.inputIndex);
-		if (!originalItem) return item;
+		if (!originalItem) {
+			throw new Error(`fokos/batchGetItems: missing original item for inputIndex ${item.inputIndex}`);
+		}
 		if (!item.found) {
 			return { ...item, item: originalItem };
 		}
@@ -234,7 +236,11 @@ export class FokosDB {
 	}
 
 	private echoBatchGetOriginalUnprocessedKey(item: BatchGetUnprocessedKey, originalItems: Map<number, ItemKey>): BatchGetUnprocessedKey {
-		return { ...item, item: originalItems.get(item.inputIndex) ?? item.item };
+		const originalItem = originalItems.get(item.inputIndex);
+		if (!originalItem) {
+			throw new Error(`fokos/batchGetItems: missing original item for inputIndex ${item.inputIndex}`);
+		}
+		return { ...item, item: originalItem };
 	}
 
 	async batchWriteItems(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult> {

--- a/apps/fokos-svc/src/lib/db.ts
+++ b/apps/fokos-svc/src/lib/db.ts
@@ -1,4 +1,13 @@
 import {
+	BatchGetItemsOptions,
+	BatchGetItemsResult,
+	BatchGetProcessedItem,
+	BatchGetUnprocessedKey,
+	BatchWriteItemOperation,
+	BatchWriteItemsOptions,
+	BatchWriteItemsResult,
+	BatchWriteProcessedItem,
+	BatchWriteUnprocessedItem,
 	DeleteItemOptions,
 	GetItemOptions,
 	GetItemResult,
@@ -8,12 +17,19 @@ import {
 	QueryItemsMeta,
 	QueryItemsOptions,
 	QueryItemsResult,
+	ItemKey,
 } from "./types.js";
 import { PartitionDO, type QueryItemsRpcRequest } from "./do-partition.js";
+import type { BatchGetRpcItem, BatchWriteRpcOperation } from "./batch-types.js";
 import { TransactionCoordinatorDO } from "./do-transaction-coordinator.js";
 import type { PartitionTopologyRouter } from "./partition-topology/router.js";
 import type { TCWriteOperation, TCReadItem } from "./transaction-types.js";
-import { validateItemKeys, validateTransactWriteOperations } from "./transaction-limits.js";
+import {
+	validateBatchGetItems,
+	validateBatchWriteOperations,
+	validateItemKeys,
+	validateTransactWriteOperations,
+} from "./transaction-limits.js";
 import { KeyCodec, type KeyBytes } from "./partition-topology/key-codec.js";
 import type { ItemCondition } from "./types.js";
 import { StaticShardedDO } from "durable-utils/do-sharding";
@@ -58,6 +74,14 @@ export type FokosDBOptions = {
 	// This is safe to increase if needed except for retrying the same transaction with the same idempotency token.
 	// Data partitions record the actual DO name they should reach out for recovering the transaction.
 	numTransactionCoordinators?: number;
+};
+
+type EncodedBatchGetWorkItem = BatchGetRpcItem & {
+	originalItem: ItemKey;
+};
+
+type EncodedBatchWriteWorkItem = BatchWriteRpcOperation & {
+	originalOperation: BatchWriteItemOperation;
 };
 
 export class FokosDB {
@@ -116,6 +140,231 @@ export class FokosDB {
 		const res = await stub.deleteItem(partitionContext, { ...opts, hashKey, sortKey });
 		// Echo the caller's original keys (no decode needed).
 		return { item: { hashKey: opts.hashKey, sortKey: opts.sortKey }, deleted: res.deleted, meta: res.meta };
+	}
+
+	async batchGetItems(opts: BatchGetItemsOptions): Promise<BatchGetItemsResult> {
+		validateBatchGetItems(opts.items);
+		const originalItems = new Map<number, ItemKey>();
+		const groups = new Map<
+			string,
+			{
+				doId: DurableObjectId;
+				partitionContext: ReturnType<PartitionTopologyRouter["pickPartition"]>["partitionContext"];
+				items: EncodedBatchGetWorkItem[];
+			}
+		>();
+
+		for (let inputIndex = 0; inputIndex < opts.items.length; inputIndex++) {
+			const item = opts.items[inputIndex];
+			const hashKey = encodeHashKey(item.hashKey);
+			const sortKey = encodeSortKey(item.sortKey);
+			const { doId, partitionContext } = this.#options.topology.pickPartition(hashKey, sortKey);
+			const originalItem = { hashKey: item.hashKey, sortKey: item.sortKey };
+			originalItems.set(inputIndex, originalItem);
+			let group = groups.get(partitionContext.doName);
+			if (!group) {
+				group = { doId, partitionContext, items: [] };
+				groups.set(partitionContext.doName, group);
+			}
+			group.items.push({ inputIndex, hashKey, sortKey, originalItem });
+		}
+
+		const items: BatchGetProcessedItem[] = [];
+		const unprocessedKeys: BatchGetUnprocessedKey[] = [];
+		const partitionMetas: BatchGetItemsResult["partitionMetas"] = [];
+		let forwardCount = 0;
+		const groupList = [...groups.values()];
+
+		const groupResults = await Promise.allSettled(
+			groupList.map(async (group) => ({
+				group,
+				result: await this.#options.ns.get(group.doId).batchGetItems(group.partitionContext, { items: group.items }),
+			})),
+		);
+
+		for (let i = 0; i < groupResults.length; i++) {
+			const groupResult = groupResults[i];
+			const group = groupList[i];
+			if (groupResult.status === "fulfilled") {
+				const result = groupResult.value.result;
+				items.push(...result.items.map((item) => this.echoBatchGetOriginalKey(item, originalItems)));
+				unprocessedKeys.push(...result.unprocessedKeys.map((item) => this.echoBatchGetOriginalUnprocessedKey(item, originalItems)));
+				partitionMetas.push(...result.partitionMetas);
+				forwardCount += result.meta.forwardCount;
+				continue;
+			}
+			for (const item of group.items) {
+				unprocessedKeys.push({
+					inputIndex: item.inputIndex,
+					item: item.originalItem,
+					reason: {
+						type: "transient_error",
+						message: groupResult.reason instanceof Error ? groupResult.reason.message : String(groupResult.reason),
+					},
+				});
+			}
+		}
+
+		items.sort((a, b) => a.inputIndex - b.inputIndex);
+		unprocessedKeys.sort((a, b) => a.inputIndex - b.inputIndex);
+
+		return {
+			items,
+			unprocessedKeys,
+			meta: {
+				requestedCount: opts.items.length,
+				processedCount: items.length,
+				unprocessedCount: unprocessedKeys.length,
+				rowsRead: partitionMetas.reduce((sum, meta) => sum + meta.rowsRead, 0),
+				rowsWritten: partitionMetas.reduce((sum, meta) => sum + meta.rowsWritten, 0),
+				forwardCount,
+				partitionsVisited: partitionMetas.length,
+			},
+			partitionMetas,
+		};
+	}
+
+	private echoBatchGetOriginalKey(item: BatchGetProcessedItem, originalItems: Map<number, ItemKey>): BatchGetProcessedItem {
+		const originalItem = originalItems.get(item.inputIndex);
+		if (!originalItem) return item;
+		if (!item.found) {
+			return { ...item, item: originalItem };
+		}
+		return { ...item, item: { ...item.item, hashKey: originalItem.hashKey, sortKey: originalItem.sortKey } };
+	}
+
+	private echoBatchGetOriginalUnprocessedKey(item: BatchGetUnprocessedKey, originalItems: Map<number, ItemKey>): BatchGetUnprocessedKey {
+		return { ...item, item: originalItems.get(item.inputIndex) ?? item.item };
+	}
+
+	async batchWriteItems(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult> {
+		validateBatchWriteOperations(opts.operations);
+
+		const originalOperations = new Map<number, BatchWriteItemOperation>();
+		const groups = new Map<
+			string,
+			{
+				doId: DurableObjectId;
+				partitionContext: ReturnType<PartitionTopologyRouter["pickPartition"]>["partitionContext"];
+				operations: EncodedBatchWriteWorkItem[];
+			}
+		>();
+
+		for (let inputIndex = 0; inputIndex < opts.operations.length; inputIndex++) {
+			const op = opts.operations[inputIndex];
+			const hashKey = encodeHashKey(op.hashKey);
+			const sortKey = encodeSortKey(op.sortKey);
+			const { doId, partitionContext } = this.#options.topology.pickPartition(hashKey, sortKey);
+			const originalOperation = { ...op, hashKey: op.hashKey, sortKey: op.sortKey };
+			originalOperations.set(inputIndex, originalOperation);
+
+			let group = groups.get(partitionContext.doName);
+			if (!group) {
+				group = { doId, partitionContext, operations: [] };
+				groups.set(partitionContext.doName, group);
+			}
+
+			if (op.operation === "put") {
+				group.operations.push({
+					inputIndex,
+					operation: "put",
+					hashKey,
+					sortKey,
+					data: op.data,
+					ttlSeconds: op.ttlSeconds,
+					ttlEpochUTCSeconds: op.ttlEpochUTCSeconds,
+					originalOperation,
+				});
+			} else {
+				group.operations.push({
+					inputIndex,
+					operation: "delete",
+					hashKey,
+					sortKey,
+					originalOperation,
+				});
+			}
+		}
+
+		const processedItems: BatchWriteProcessedItem[] = [];
+		const unprocessedItems: BatchWriteUnprocessedItem[] = [];
+		const partitionMetas: BatchWriteItemsResult["partitionMetas"] = [];
+		let forwardCount = 0;
+		const groupList = [...groups.values()];
+
+		const groupResults = await Promise.allSettled(
+			groupList.map(async (group) => ({
+				group,
+				result: await this.#options.ns.get(group.doId).batchWriteItems(group.partitionContext, { operations: group.operations }),
+			})),
+		);
+
+		for (let i = 0; i < groupResults.length; i++) {
+			const groupResult = groupResults[i];
+			const group = groupList[i];
+			if (groupResult.status === "fulfilled") {
+				const result = groupResult.value.result;
+				processedItems.push(...result.processedItems.map((item) => this.echoBatchWriteOriginalItem(item, originalOperations)));
+				unprocessedItems.push(
+					...result.unprocessedItems.map((item) => this.echoBatchWriteOriginalUnprocessedItem(item, originalOperations)),
+				);
+				partitionMetas.push(...result.partitionMetas);
+				forwardCount += result.meta.forwardCount;
+				continue;
+			}
+
+			for (const op of group.operations) {
+				unprocessedItems.push({
+					inputIndex: op.inputIndex,
+					operation: op.operation,
+					item: this.batchWriteOriginalItem(op.inputIndex, originalOperations),
+					reason: {
+						type: "transient_error",
+						message: groupResult.reason instanceof Error ? groupResult.reason.message : String(groupResult.reason),
+					},
+				});
+			}
+		}
+
+		processedItems.sort((a, b) => a.inputIndex - b.inputIndex);
+		unprocessedItems.sort((a, b) => a.inputIndex - b.inputIndex);
+
+		return {
+			processedItems,
+			unprocessedItems,
+			meta: {
+				requestedCount: opts.operations.length,
+				processedCount: processedItems.length,
+				unprocessedCount: unprocessedItems.length,
+				rowsRead: partitionMetas.reduce((sum, meta) => sum + meta.rowsRead, 0),
+				rowsWritten: partitionMetas.reduce((sum, meta) => sum + meta.rowsWritten, 0),
+				forwardCount,
+				partitionsVisited: partitionMetas.length,
+			},
+			partitionMetas,
+		};
+	}
+
+	private echoBatchWriteOriginalItem(
+		item: BatchWriteProcessedItem,
+		originalOperations: Map<number, BatchWriteItemOperation>,
+	): BatchWriteProcessedItem {
+		return { ...item, item: this.batchWriteOriginalItem(item.inputIndex, originalOperations) };
+	}
+
+	private echoBatchWriteOriginalUnprocessedItem(
+		item: BatchWriteUnprocessedItem,
+		originalOperations: Map<number, BatchWriteItemOperation>,
+	): BatchWriteUnprocessedItem {
+		return { ...item, item: this.batchWriteOriginalItem(item.inputIndex, originalOperations) };
+	}
+
+	private batchWriteOriginalItem(inputIndex: number, originalOperations: Map<number, BatchWriteItemOperation>): ItemKey {
+		const originalOperation = originalOperations.get(inputIndex);
+		if (!originalOperation) {
+			throw new Error(`fokos/batchWriteItems: missing original operation for inputIndex ${inputIndex}`);
+		}
+		return { hashKey: originalOperation.hashKey, sortKey: originalOperation.sortKey };
 	}
 
 	async transactWriteItems(opts: {

--- a/apps/fokos-svc/src/lib/do-partition.test.ts
+++ b/apps/fokos-svc/src/lib/do-partition.test.ts
@@ -10,6 +10,7 @@ import { HashPartitionTopologyImpl, RANGE_PROMOTION_FRACTION } from "./partition
 import type { SplitStatusKVItem } from "./partition-topology/split-state.js";
 import { KeyBytes, KeyCodec } from "./partition-topology/key-codec.js";
 import invariant from "./invariant.js";
+import { MAX_BATCH_FORWARDED_SUB_BATCH_BYTES } from "./transaction-limits.js";
 
 const kb = (s: string) => KeyCodec.encode(s);
 
@@ -984,6 +985,122 @@ describe("PartitionDO - splitting", () => {
 			expect(result.meta.forwardCount).toBe(1);
 			expect(result.meta.servedByActorName).not.toBe(ctx.doName);
 		});
+
+		it("batchWriteItems forwards through a completed hash split and reports the child leaf meta", async ({ expect }) => {
+			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
+
+			await triggerHashSplitThreshold(stub, ctx, 1);
+			await drainSplitTree(stub);
+
+			const result = await stub.batchWriteItems(ctx, {
+				operations: [{ inputIndex: 0, operation: "put", hashKey: kb("batch-forwarded-key"), sortKey: kb("sk"), data: "via-child" }],
+			});
+
+			expect(result.unprocessedItems).toEqual([]);
+			expect(result.processedItems).toEqual([{ inputIndex: 0, operation: "put", item: { hashKey: "batch-forwarded-key", sortKey: "sk" } }]);
+			expect(result.meta.forwardCount).toBe(1);
+			expect(result.meta.rowsWritten).toBe(0);
+			expect(result.partitionMetas).toHaveLength(1);
+			expect(result.partitionMetas[0].servedByActorName).not.toBe(ctx.doName);
+			expect(result.partitionMetas[0].rowsWritten).toBeGreaterThan(0);
+
+			const read = await stub.getItem(ctx, { hashKey: "batch-forwarded-key", sortKey: "sk" });
+			expect(read).toMatchObject({ found: true, item: { data: "via-child" }, meta: { forwardCount: 1 } });
+		});
+
+		it("batchWriteItems forwards a single-key item through a completed hash split", async ({ expect }) => {
+			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
+
+			await triggerHashSplitThreshold(stub, ctx, 1);
+			await drainSplitTree(stub);
+
+			const result = await stub.batchWriteItems(ctx, {
+				operations: [
+					{
+						inputIndex: 0,
+						operation: "put",
+						hashKey: kb("batch-forwarded-single-key"),
+						sortKey: KeyCodec.encodeOptional(undefined),
+						data: "via-child",
+					},
+				],
+			});
+
+			expect(result.unprocessedItems).toEqual([]);
+			expect(result.processedItems).toEqual([
+				{ inputIndex: 0, operation: "put", item: { hashKey: "batch-forwarded-single-key", sortKey: undefined } },
+			]);
+			expect(result.meta.forwardCount).toBe(1);
+			expect(result.partitionMetas).toHaveLength(1);
+			expect(result.partitionMetas[0].servedByActorName).not.toBe(ctx.doName);
+
+			const read = await stub.getItem(ctx, { hashKey: "batch-forwarded-single-key" });
+			expect(read).toMatchObject({ found: true, item: { data: "via-child" }, meta: { forwardCount: 1 } });
+		});
+
+		it("batchWriteItems keeps local ownership while a split is only queued", async ({ expect }) => {
+			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
+
+			await runInDurableObject(stub, async (instance: PartitionDO) => {
+				const chunkBytes = Math.floor(RANGE_PROMOTION_FRACTION * 1024 * 1024 * 0.65);
+				const tData = "x".repeat(chunkBytes);
+				for (let i = 0; ; i++) {
+					await instance.putItem(ctx, { hashKey: `queued-split-${i}`, sortKey: "sk", data: tData });
+					if ((await instance.status()).splitStatus?.status === "split_queued") break;
+				}
+
+				const result = await instance.batchWriteItems(ctx, {
+					operations: [
+						{ inputIndex: 0, operation: "put", hashKey: kb("queued-local-a"), sortKey: kb("sk"), data: "a" },
+						{ inputIndex: 1, operation: "put", hashKey: kb("queued-local-b"), sortKey: kb("sk"), data: "b" },
+					],
+				});
+
+				expect((await instance.status()).splitStatus?.status).toBe("split_queued");
+				expect(result.unprocessedItems).toEqual([]);
+				expect(result.processedItems.map((item) => item.inputIndex)).toEqual([0, 1]);
+				expect(result.meta.forwardCount).toBe(0);
+				expect(result.partitionMetas).toHaveLength(1);
+				expect(result.partitionMetas[0].servedByActorName).toBe(ctx.doName);
+			});
+
+			await expect(stub.getItem(ctx, { hashKey: "queued-local-a", sortKey: "sk" })).resolves.toMatchObject({
+				found: true,
+				item: { data: "a" },
+			});
+		});
+
+		it("batchWriteItems rejects an oversized forwarded operation without calling the child", async ({ expect }) => {
+			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
+
+			await triggerHashSplitThreshold(stub, ctx, 1);
+			await drainSplitTree(stub);
+
+			const result = await stub.batchWriteItems(ctx, {
+				operations: [
+					{
+						inputIndex: 0,
+						operation: "put",
+						hashKey: kb("too-large-forward"),
+						sortKey: kb("sk"),
+						data: "x".repeat(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES + 1),
+					},
+				],
+			});
+
+			expect(result.processedItems).toEqual([]);
+			expect(result.unprocessedItems).toEqual([
+				{
+					inputIndex: 0,
+					operation: "put",
+					item: { hashKey: "too-large-forward", sortKey: "sk" },
+					reason: { type: "partition_over_limit" },
+				},
+			]);
+			expect(result.meta.forwardCount).toBe(0);
+			expect(result.partitionMetas).toEqual([]);
+			await expect(stub.getItem(ctx, { hashKey: "too-large-forward", sortKey: "sk" })).resolves.toMatchObject({ found: false });
+		});
 	});
 
 	describe("multi-level splits", async () => {
@@ -1273,6 +1390,64 @@ describe("PartitionDO - splitting", () => {
 			expect((await childStub.status()).migrationStatus).toBe("migration_completed");
 		});
 
+		it("batchWriteItems maps a migrating child failure to unprocessed and keeps another child success", async ({ expect }) => {
+			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
+
+			await triggerHashSplitThreshold(stub, ctx, 1);
+
+			let releaseMigration!: () => void;
+			const migrationGate = new Promise<void>((resolve) => {
+				releaseMigration = resolve;
+			});
+			const plannedChildren = PartitionIdHelper.calculateHashChildPartitionIds(ctx);
+			const blockedChildName = plannedChildren[0].doName;
+			await runInDurableObject(env.PARTITION_DO.get(env.PARTITION_DO.idFromName(blockedChildName)), async (instance: PartitionDO) => {
+				instance.__testing__beforeMigrationComplete = () => migrationGate;
+			});
+
+			await waitForAlarm(stub);
+
+			const parentState = await stub.status();
+			const childContexts = (parentState.splitStatus as SplitStartedOrCompleted).childPartitionContexts;
+			const blockedCtx = childContexts.find((childCtx) => childCtx.doName === blockedChildName)!;
+			const readyCtx = childContexts.find((childCtx) => childCtx.doName !== blockedChildName)!;
+			const readyStub = env.PARTITION_DO.get(env.PARTITION_DO.idFromName(readyCtx.doName));
+			await waitForAlarm(readyStub);
+			expect((await readyStub.status()).migrationStatus).toBe("migration_completed");
+			expect((await env.PARTITION_DO.get(env.PARTITION_DO.idFromName(blockedCtx.doName)).status()).migrationStatus).toBe(
+				"migration_migrating",
+			);
+
+			const blockedKey = await keyForHashChild(stub, ctx, blockedCtx, "batch-blocked-child");
+			const readyKey = await keyForHashChild(stub, ctx, readyCtx, "batch-ready-child");
+			const result = await stub.batchWriteItems(ctx, {
+				operations: [
+					{ inputIndex: 0, operation: "put", hashKey: kb(blockedKey), sortKey: kb("sk"), data: "blocked" },
+					{ inputIndex: 1, operation: "put", hashKey: kb(readyKey), sortKey: kb("sk"), data: "ready" },
+				],
+			});
+
+			expect(result.processedItems).toEqual([{ inputIndex: 1, operation: "put", item: { hashKey: readyKey, sortKey: "sk" } }]);
+			expect(result.unprocessedItems).toEqual([
+				{
+					inputIndex: 0,
+					operation: "put",
+					item: { hashKey: blockedKey, sortKey: "sk" },
+					reason: { type: "transient_error", message: expect.stringContaining("split in progress") },
+				},
+			]);
+			expect(result.meta.forwardCount).toBe(2);
+			expect(result.partitionMetas).toHaveLength(1);
+			expect(result.partitionMetas[0].servedByActorName).toBe(readyCtx.doName);
+			await expect(stub.getItem(ctx, { hashKey: readyKey, sortKey: "sk" })).resolves.toMatchObject({
+				found: true,
+				item: { data: "ready" },
+			});
+
+			releaseMigration();
+			await drainSplitTree(stub);
+		});
+
 		it("getItem on a child reads through to the parent while migration is in progress", async ({ expect }) => {
 			const { ctx, stub } = makeStub({ hashSplitN: 2, hashSplitConditions: { maxSizeMb: 1 } });
 
@@ -1531,6 +1706,41 @@ describe("PartitionDO - partitionId encoding", () => {
 	});
 });
 
+async function keyForHashChild(
+	parentStub: DurableObjectStub<PartitionDO>,
+	parentCtx: PartitionContextResolved,
+	childCtx: PartitionContextResolved,
+	prefix: string,
+): Promise<string> {
+	let match: string | undefined;
+	await runInDurableObject(parentStub, async (_instance: PartitionDO, doCtx: DurableObjectState) => {
+		const topology = new HashPartitionTopologyImpl(parentCtx, doCtx);
+		const isCorrectChild = topology.makeIsCorrectChildHashPartition(parentCtx, childCtx);
+		for (let i = 0; i < 10_000; i++) {
+			const candidate = `${prefix}-${i}`;
+			if (isCorrectChild(kb(candidate))) {
+				match = candidate;
+				return;
+			}
+		}
+	});
+	invariant(match, `could not find key for child ${childCtx.doName}`);
+	return match;
+}
+
+function rangeOwnerForSortKey(children: PartitionContextResolved[], sortKey: string): PartitionContextResolved {
+	const sk = kb(sortKey);
+	const owner = children.find((childCtx) => {
+		const rp = childCtx.rangePartition;
+		invariant(rp, "range child missing rangePartition");
+		const start = rp.startBoundary ?? KeyCodec.encodeOptional(undefined);
+		const end = rp.endBoundary;
+		return KeyCodec.compare(sk, start) >= 0 && (end === null || KeyCodec.compare(sk, end) < 0);
+	});
+	invariant(owner, `could not find range owner for sort key ${sortKey}`);
+	return owner;
+}
+
 async function waitForAlarm(stub: DurableObjectStub<PartitionDO>) {
 	// runDurableObjectAlarm drains any pending alarm. The auto-fired alarm (from Miniflare
 	// detecting an immediate schedule) may still be in progress when putItem returns.
@@ -1698,9 +1908,7 @@ describe("PartitionDO — promotion detection and queuing", () => {
 
 describe("PartitionDO — promotion cutover deferral and routing", () => {
 	it("defers cutover to 'promoting' while the key has a pending transaction lock", async () => {
-		const { ctx, stub } = makeStub({
-			hashSplitConditions: { maxSizeMb: PROMOTION_TEST_MAX_SIZE_MB },
-		});
+		const { ctx, stub } = makeStub();
 		await stub.putItem(ctx, { hashKey: "alice", sortKey: "sk1", data: PROMOTION_BIG_DATA });
 
 		// Lock alice/sk1 with a prepare so the lock-free check in startPromotion defers.
@@ -1708,13 +1916,24 @@ describe("PartitionDO — promotion cutover deferral and routing", () => {
 		const coordId = env.TRANSACTION_COORDINATOR_DO.newUniqueId().toString();
 		const lockResult = await stub.prepare(ctx, {
 			transactionId: txId,
-			transactionTimestamp: Date.now(),
+			transactionTimestamp: Date.now() + 1_000,
 			coordinatorDoId: coordId,
 			items: [{ hashKey: kb("alice"), sortKey: kb("sk1"), operation: "put", data: "pending" }],
 		});
 		expect(lockResult.outcome).toBe("accepted");
 
-		// Detection queued alice but cutover was deferred — key must still be 'queued'.
+		await runInDurableObject(stub, async (_instance: PartitionDO, doCtx: DurableObjectState) => {
+			const now = Date.now();
+			doCtx.storage.sql.exec(
+				`INSERT INTO promoted_keys (hash_key, status, gc_done, created_at, updated_at) VALUES (?, 'queued', 0, ?, ?)`,
+				kb("alice"),
+				now,
+				now,
+			);
+			await doCtx.storage.setAlarm(Date.now());
+		});
+
+		// The queued key was driven, but cutover was deferred because the pending lock exists.
 		await vi.waitFor(
 			async () => {
 				await waitForAlarm(stub);
@@ -1780,6 +1999,48 @@ describe("PartitionDO — promotion cutover deferral and routing", () => {
 		// Item is in the range root.
 		const g = await rangeRootStub.getItem(rangeRootCtx, { hashKey: "alice", sortKey: "sk2" });
 		expect(g).toMatchObject({ found: true, item: { data: "in-range" } });
+	});
+
+	it("batchWriteItems mixes promoted-key forwarding with local siblings in input order", async () => {
+		const { ctx, stub } = makeStub({
+			hashSplitConditions: { maxSizeMb: PROMOTION_TEST_MAX_SIZE_MB },
+		});
+		await stub.putItem(ctx, { hashKey: "alice", sortKey: "sk1", data: PROMOTION_BIG_DATA });
+		const { partitionContext: rangeRootCtx } = resolveRangePartitionContext(ctx, kb("alice"), null, null);
+		const rangeRootStub = env.PARTITION_DO.get(env.PARTITION_DO.idFromName(rangeRootCtx.doName));
+		await vi.waitFor(
+			async () => {
+				await waitForAlarm(stub);
+				await waitForAlarm(rangeRootStub);
+				if ((await stub.status()).promotedKeys.find((e) => KeyCodec.compare(e.hashKey, kb("alice")) === 0)?.status !== "promoted")
+					throw new Error("not yet promoted");
+			},
+			{ timeout: 5000, interval: 100 },
+		);
+
+		const result = await stub.batchWriteItems(ctx, {
+			operations: [
+				{ inputIndex: 0, operation: "put", hashKey: kb("alice"), sortKey: kb("sk2"), data: "range-data" },
+				{ inputIndex: 1, operation: "put", hashKey: kb("bob"), sortKey: kb("sk1"), data: "local-data" },
+			],
+		});
+
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.processedItems).toEqual([
+			{ inputIndex: 0, operation: "put", item: { hashKey: "alice", sortKey: "sk2" } },
+			{ inputIndex: 1, operation: "put", item: { hashKey: "bob", sortKey: "sk1" } },
+		]);
+		expect(result.meta.forwardCount).toBe(1);
+		expect(result.partitionMetas.map((meta) => meta.servedByActorName).sort()).toEqual([ctx.doName, rangeRootCtx.doName].sort());
+
+		await expect(rangeRootStub.getItem(rangeRootCtx, { hashKey: "alice", sortKey: "sk2" })).resolves.toMatchObject({
+			found: true,
+			item: { data: "range-data" },
+		});
+		await expect(stub.getItem(ctx, { hashKey: "bob", sortKey: "sk1" })).resolves.toMatchObject({
+			found: true,
+			item: { data: "local-data" },
+		});
 	});
 });
 
@@ -2071,6 +2332,38 @@ describe("PartitionDO — range split", () => {
 			expect(g.found).toBe(true);
 			expect(g.meta.servedByActorName, `sk ${sk} should be served by its owning child`).toBe(owners[0].doName);
 		}
+	});
+
+	it("batchWriteItems on a split range root forwards to the range child by sort key", async () => {
+		const N = 4;
+		const { rootCtx, rootStub } = await makeQueuedRangeRoot(N);
+		await vi.waitFor(
+			async () => {
+				await drainSplitTree(rootStub);
+				const s = await rootStub.status();
+				if (s.splitStatus?.status !== "split_completed") throw new Error("split not completed yet");
+			},
+			{ timeout: 5000, interval: 100 },
+		);
+		const status = (await rootStub.status()).splitStatus as SplitStartedOrCompleted;
+		const sortKey = "sk999-batch-write";
+		const owner = rangeOwnerForSortKey(status.childPartitionContexts, sortKey);
+
+		const result = await rootStub.batchWriteItems(rootCtx, {
+			operations: [{ inputIndex: 0, operation: "put", hashKey: kb("alice"), sortKey: kb(sortKey), data: "range-child-write" }],
+		});
+
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.processedItems).toEqual([{ inputIndex: 0, operation: "put", item: { hashKey: "alice", sortKey } }]);
+		expect(result.meta.forwardCount).toBe(1);
+		expect(result.meta.rowsWritten).toBe(0);
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0].servedByActorName).toBe(owner.doName);
+		await expect(rootStub.getItem(rootCtx, { hashKey: "alice", sortKey })).resolves.toMatchObject({
+			found: true,
+			item: { data: "range-child-write" },
+			meta: { servedByActorName: owner.doName },
+		});
 	});
 
 	it("creates a brand-new leftmost child distinct from the router (no retain-leftmost)", async () => {

--- a/apps/fokos-svc/src/lib/do-partition.test.ts
+++ b/apps/fokos-svc/src/lib/do-partition.test.ts
@@ -204,6 +204,21 @@ describe("PartitionDO - putItem / getItem", () => {
 			expect(result).toMatchObject({ found: true, item: { data: "v2" } });
 			if (result.found) expect(result.item.ttlEpochUTCSeconds).toBeUndefined();
 		});
+
+		it("converts a relative ttlSeconds to an absolute ttlEpochUTCSeconds on put", async ({ expect }) => {
+			const { ctx, stub } = makeStub();
+			const before = Math.floor(Date.now() / 1000);
+
+			await stub.putItem(ctx, { hashKey: "hk", sortKey: "sk", data: "val", ttlSeconds: 3600 });
+			const result = await stub.getItem(ctx, { hashKey: "hk", sortKey: "sk" });
+
+			expect(result.found).toBe(true);
+			if (result.found) {
+				const ttl = result.item.ttlEpochUTCSeconds;
+				expect(ttl).toBeGreaterThanOrEqual(before + 3600);
+				expect(ttl).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 3600);
+			}
+		});
 	});
 
 	it("stores and retrieves an item with no sortKey", async ({ expect }) => {

--- a/apps/fokos-svc/src/lib/do-partition.ts
+++ b/apps/fokos-svc/src/lib/do-partition.ts
@@ -4,11 +4,21 @@ import {
 	DeleteItemResult,
 	GetItemOptions,
 	GetItemResult,
+	ItemKey,
 	OperationMetrics,
 	PartitionInfo,
 	PutItemOptions,
 	PutItemResult,
 } from "./types.js";
+import type {
+	BatchGetItemsRpcRequest,
+	BatchGetItemsRpcResult,
+	BatchGetRpcItem,
+	BatchRetryableFailure,
+	BatchWriteItemsRpcRequest,
+	BatchWriteItemsRpcResult,
+	BatchWriteRpcOperation,
+} from "./batch-types.js";
 import type {
 	CancelRequest,
 	CancelResponse,
@@ -71,6 +81,7 @@ import {
 	type SkInterval,
 } from "./query/sk-interval.js";
 import { PageBudget } from "./query/page-budget.js";
+import { estimateEncodedBatchWriteForwardedOperationBytes, MAX_BATCH_FORWARDED_SUB_BATCH_BYTES } from "./transaction-limits.js";
 
 function isPhantomBounceError(e: unknown): boolean {
 	return e instanceof Error && e.message.includes("phantom-bounce");
@@ -89,6 +100,8 @@ function sumSqlMetrics(...results: Array<{ rowsRead: number; rowsWritten: number
 export interface PartitionAPI {
 	putItem(ctx: PartitionContext, opts: PutItemOptions): Promise<PutItemResult>;
 	getItem(ctx: PartitionContext, opts: GetItemOptions): Promise<GetItemResult>;
+	batchGetItems(ctx: PartitionContext, req: BatchGetItemsRpcRequest): Promise<BatchGetItemsRpcResult>;
+	batchWriteItems(ctx: PartitionContext, req: BatchWriteItemsRpcRequest): Promise<BatchWriteItemsRpcResult>;
 	deleteItem(ctx: PartitionContext, opts: DeleteItemOptions): Promise<DeleteItemResult>;
 }
 
@@ -133,6 +146,9 @@ export type QueryItemsRpcResult = {
 type PartitionDOStub = {
 	putItem(ctx: PartitionContextResolved, opts: PutItemOptions): Promise<PutItemResult>;
 	getItem(ctx: PartitionContextResolved, opts: GetItemOptions): Promise<GetItemResult>;
+	batchGetItems(ctx: PartitionContextResolved, req: BatchGetItemsRpcRequest): Promise<BatchGetItemsRpcResult>;
+	batchGetItemsDirect(req: BatchGetItemsRpcRequest): Promise<BatchGetItemsRpcResult>;
+	batchWriteItems(ctx: PartitionContextResolved, req: BatchWriteItemsRpcRequest): Promise<BatchWriteItemsRpcResult>;
 	deleteItem(ctx: PartitionContextResolved, opts: DeleteItemOptions): Promise<DeleteItemResult>;
 	prepare(ctx: PartitionContextResolved, request: PrepareRequest): Promise<PrepareResponse>;
 	commit(ctx: PartitionContextResolved, request: CommitRequest): Promise<CommitResponse>;
@@ -411,6 +427,162 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 	// Called by child partitions during migration to avoid a forwarding loop back into the child.
 	async getItemDirect(opts: GetItemOptions): Promise<GetItemResult> {
 		return await this.readItemLocally(this.pCtx(), opts);
+	}
+
+	async batchGetItems(pCtx: PartitionContextResolved, req: BatchGetItemsRpcRequest): Promise<BatchGetItemsRpcResult> {
+		this.ensurePartitionContext(pCtx);
+
+		if (await this.ensureMigration("batchGetItems", false)) {
+			const parentCtx = this.ctx.storage.kv.get<PartitionContextResolved>(PartitionDO.KV_KEYS.PARENT_PARTITION_CONTEXT);
+			invariant(parentCtx, "fokos/partition.batchGetItems: no parent partition context stored during migration");
+			const parentId = this.env[parentCtx.ns].idFromName(parentCtx.doName);
+			const parentStub = this.env[parentCtx.ns].get(parentId) as PartitionDOStub;
+			const result = await parentStub.batchGetItemsDirect(req);
+			if (isHashPartition(pCtx)) {
+				const myDepth = PartitionIdHelper.depth(this.pCtx()._partitionIdBytes!);
+				return { ...result, meta: { ...result.meta, hashDepth: myDepth } };
+			}
+			return result;
+		}
+
+		const { local, forwarded, unplaceable } = this.groupItemsByRouting(req.items);
+
+		const items: BatchGetItemsRpcResult["items"] = [];
+		const unprocessedKeys: BatchGetItemsRpcResult["unprocessedKeys"] = unplaceable.map((item) =>
+			this.batchGetUnprocessedKey(item, { type: "partition_over_limit" }),
+		);
+		const partitionMetas: BatchGetItemsRpcResult["partitionMetas"] = [];
+		let descendantForwards = 0;
+		let forwardedCalls = 0;
+		let localRowsRead = 0;
+
+		if (local.length > 0) {
+			const localResult = this.batchGetItemsLocal(pCtx, { items: local });
+			items.push(...localResult.items);
+			unprocessedKeys.push(...localResult.unprocessedKeys);
+			partitionMetas.push(...localResult.partitionMetas);
+			localRowsRead += localResult.meta.rowsRead;
+		}
+
+		const forwardedEntries = [...forwarded.values()];
+		if (forwardedEntries.length > 0) {
+			const childResults = await Promise.allSettled(
+				forwardedEntries.map(async ({ pCtx: childPCtx, items }) => ({
+					childPCtx,
+					items,
+					result: await this.getChildStub(childPCtx).batchGetItems(childPCtx, { items }),
+				})),
+			);
+			for (let i = 0; i < childResults.length; i++) {
+				const childResult = childResults[i];
+				const childItems = forwardedEntries[i].items;
+				forwardedCalls++;
+				if (childResult.status === "fulfilled") {
+					items.push(...childResult.value.result.items);
+					unprocessedKeys.push(...childResult.value.result.unprocessedKeys);
+					partitionMetas.push(...childResult.value.result.partitionMetas);
+					descendantForwards += childResult.value.result.meta.forwardCount;
+					continue;
+				}
+				for (const item of childItems) {
+					unprocessedKeys.push(
+						this.batchGetUnprocessedKey(item, {
+							type: "transient_error",
+							message: childResult.reason instanceof Error ? childResult.reason.message : String(childResult.reason),
+						}),
+					);
+				}
+			}
+		}
+
+		return {
+			items,
+			unprocessedKeys,
+			meta: this.partitionMeta(pCtx, {
+				rowsRead: localRowsRead,
+				rowsWritten: 0,
+				forwardCount: forwardedCalls + descendantForwards,
+			}),
+			partitionMetas,
+		};
+	}
+
+	// Direct read bypassing split forwarding — used by migrating children to read parent-local rows.
+	async batchGetItemsDirect(req: BatchGetItemsRpcRequest): Promise<BatchGetItemsRpcResult> {
+		return this.batchGetItemsLocal(this.pCtx(), req);
+	}
+
+	async batchWriteItems(pCtx: PartitionContextResolved, req: BatchWriteItemsRpcRequest): Promise<BatchWriteItemsRpcResult> {
+		this.ensurePartitionContext(pCtx);
+		await this.ensureMigration("batchWriteItems");
+
+		const { local, forwarded, unplaceable } = this.groupItemsByRouting(req.operations);
+
+		const processedItems: BatchWriteItemsRpcResult["processedItems"] = [];
+		const unprocessedItems: BatchWriteItemsRpcResult["unprocessedItems"] = unplaceable.map((op) =>
+			this.batchWriteUnprocessedItem(op, { type: "partition_over_limit" }),
+		);
+		const partitionMetas: BatchWriteItemsRpcResult["partitionMetas"] = [];
+		let localRowsRead = 0;
+		let localRowsWritten = 0;
+		let descendantForwards = 0;
+		let forwardedCalls = 0;
+
+		if (local.length > 0) {
+			const localResult = await this.batchWriteItemsLocal(pCtx, { operations: local });
+			processedItems.push(...localResult.processedItems);
+			unprocessedItems.push(...localResult.unprocessedItems);
+			partitionMetas.push(...localResult.partitionMetas);
+			localRowsRead += localResult.meta.rowsRead;
+			localRowsWritten += localResult.meta.rowsWritten;
+		}
+
+		const { chunks: forwardedChunks, overLimitItems } = this.batchWriteForwardedChunks(forwarded);
+		unprocessedItems.push(...overLimitItems);
+
+		if (forwardedChunks.length > 0) {
+			const childResults = await Promise.allSettled(
+				forwardedChunks.map(async ({ pCtx: childPCtx, operations }) => ({
+					childPCtx,
+					operations,
+					result: await this.getChildStub(childPCtx).batchWriteItems(childPCtx, { operations }),
+				})),
+			);
+			for (let i = 0; i < childResults.length; i++) {
+				const childResult = childResults[i];
+				const childOperations = forwardedChunks[i].operations;
+				forwardedCalls++;
+				if (childResult.status === "fulfilled") {
+					processedItems.push(...childResult.value.result.processedItems);
+					unprocessedItems.push(...childResult.value.result.unprocessedItems);
+					partitionMetas.push(...childResult.value.result.partitionMetas);
+					descendantForwards += childResult.value.result.meta.forwardCount;
+					continue;
+				}
+				for (const op of childOperations) {
+					unprocessedItems.push(
+						this.batchWriteUnprocessedItem(op, {
+							type: "transient_error",
+							message: childResult.reason instanceof Error ? childResult.reason.message : String(childResult.reason),
+						}),
+					);
+				}
+			}
+		}
+
+		processedItems.sort((a, b) => a.inputIndex - b.inputIndex);
+		unprocessedItems.sort((a, b) => a.inputIndex - b.inputIndex);
+
+		return {
+			processedItems,
+			unprocessedItems,
+			meta: this.partitionMeta(pCtx, {
+				rowsRead: localRowsRead,
+				rowsWritten: localRowsWritten,
+				forwardCount: forwardedCalls + descendantForwards,
+			}),
+			partitionMetas,
+		};
 	}
 
 	async queryItems(pCtx: PartitionContextResolved, req: QueryItemsRpcRequest): Promise<QueryItemsRpcResult> {
@@ -1372,20 +1544,193 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 		return this.env[this.pCtx().ns].get(childId);
 	}
 
-	private readItemLocally(pCtx: PartitionContextResolved, opts: GetItemOptions): GetItemResult {
-		const res = this.#store.getItem(PartitionDO.keyIn(opts.hashKey), PartitionDO.optKeyIn(opts.sortKey));
-		const { rowsRead, rowsWritten } = res;
-		const result = res.row;
-		const actorMeta = {
-			rowsRead,
-			rowsWritten,
+	private batchGetItemsLocal(pCtx: PartitionContextResolved, req: BatchGetItemsRpcRequest): BatchGetItemsRpcResult {
+		const items: BatchGetItemsRpcResult["items"] = [];
+		let rowsRead = 0;
+		for (const item of req.items) {
+			const res = this.#store.getItem(PartitionDO.keyIn(item.hashKey), PartitionDO.keyIn(item.sortKey));
+			rowsRead += res.rowsRead;
+			const itemKey = this.publicItemKey(item);
+			if (!res.row) {
+				items.push({ inputIndex: item.inputIndex, found: false, item: itemKey });
+				continue;
+			}
+			items.push({
+				inputIndex: item.inputIndex,
+				found: true,
+				item: {
+					...itemKey,
+					data: res.row.data,
+					ttlEpochUTCSeconds: res.row.ttl_epoch_utc_seconds ? Number(res.row.ttl_epoch_utc_seconds) : undefined,
+					version: res.row.v,
+				},
+			});
+		}
+
+		const meta = this.partitionMeta(pCtx, { rowsRead, rowsWritten: 0, forwardCount: 0 });
+		return {
+			items,
+			unprocessedKeys: [],
+			meta,
+			partitionMetas: req.items.length > 0 ? [meta] : [],
+		};
+	}
+
+	private batchGetUnprocessedKey(item: BatchGetRpcItem, reason: BatchRetryableFailure): BatchGetItemsRpcResult["unprocessedKeys"][number] {
+		return { inputIndex: item.inputIndex, item: this.publicItemKey(item), reason };
+	}
+
+	private batchWriteForwardedChunks(forwarded: Map<string, { pCtx: PartitionContextResolved; items: BatchWriteRpcOperation[] }>): {
+		chunks: Array<{ pCtx: PartitionContextResolved; operations: BatchWriteRpcOperation[] }>;
+		overLimitItems: BatchWriteItemsRpcResult["unprocessedItems"];
+	} {
+		const chunks: Array<{ pCtx: PartitionContextResolved; operations: BatchWriteRpcOperation[] }> = [];
+		const overLimitItems: BatchWriteItemsRpcResult["unprocessedItems"] = [];
+
+		for (const { pCtx, items } of forwarded.values()) {
+			let current: BatchWriteRpcOperation[] = [];
+			let currentBytes = 0;
+			const flush = () => {
+				if (current.length === 0) return;
+				chunks.push({ pCtx, operations: current });
+				current = [];
+				currentBytes = 0;
+			};
+
+			for (const op of items) {
+				const opBytes = estimateEncodedBatchWriteForwardedOperationBytes(op);
+				if (opBytes > MAX_BATCH_FORWARDED_SUB_BATCH_BYTES) {
+					flush();
+					overLimitItems.push(this.batchWriteUnprocessedItem(op, { type: "partition_over_limit" }));
+					continue;
+				}
+				if (current.length > 0 && currentBytes + opBytes > MAX_BATCH_FORWARDED_SUB_BATCH_BYTES) {
+					flush();
+				}
+				current.push(op);
+				currentBytes += opBytes;
+			}
+			flush();
+		}
+
+		return { chunks, overLimitItems };
+	}
+
+	private async batchWriteItemsLocal(pCtx: PartitionContextResolved, req: BatchWriteItemsRpcRequest): Promise<BatchWriteItemsRpcResult> {
+		const processedItems: BatchWriteItemsRpcResult["processedItems"] = [];
+		const unprocessedItems: BatchWriteItemsRpcResult["unprocessedItems"] = [];
+		let rowsRead = 0;
+		let rowsWritten = 0;
+
+		for (const op of req.operations) {
+			// A previous item can queue split/promotion work. Re-check before every local apply
+			// so this DO never writes locally after ownership has moved to a child/range router.
+			const ownership = this.groupItemsByRouting([op]);
+			if (ownership.unplaceable.length > 0) {
+				unprocessedItems.push(this.batchWriteUnprocessedItem(op, { type: "partition_over_limit" }));
+				continue;
+			}
+			if (ownership.forwarded.size > 0) {
+				unprocessedItems.push(
+					this.batchWriteUnprocessedItem(op, {
+						type: "transient_error",
+						message: "fokos/partition.batchWriteItems: ownership changed during local batch; retry item",
+					}),
+				);
+				continue;
+			}
+
+			const hashKey = PartitionDO.keyIn(op.hashKey);
+			const sortKey = PartitionDO.keyIn(op.sortKey);
+			const pendingRow = this.#store.pendingLockFor(hashKey, sortKey);
+			if (pendingRow) {
+				unprocessedItems.push(
+					this.batchWriteUnprocessedItem(op, {
+						type: "pending_lock",
+						conflictingTransactionId: pendingRow.transaction_id,
+					}),
+				);
+				continue;
+			}
+
+			try {
+				if (op.operation === "put") {
+					const writeRes = this.#store.upsertItem({
+						hk: hashKey,
+						sk: sortKey,
+						data: op.data,
+						ttlEpochUtcSeconds: op.ttlEpochUTCSeconds ?? null,
+						lastTransactionTs: Date.now(),
+					});
+					rowsRead += writeRes.rowsRead;
+					rowsWritten += writeRes.rowsWritten;
+					this.#promotion.maybeQueuePromotion(pCtx, hashKey, writeRes.keyEstBytes);
+					await this.checkSplits(pCtx, hashKey, sortKey);
+				} else {
+					const writeRes = this.#store.deleteItem({ hk: hashKey, sk: sortKey, watermarkTs: Date.now() });
+					rowsRead += writeRes.rowsRead;
+					rowsWritten += writeRes.rowsWritten;
+				}
+
+				processedItems.push({
+					inputIndex: op.inputIndex,
+					operation: op.operation,
+					item: this.publicItemKey(op),
+				});
+			} catch (err) {
+				unprocessedItems.push(
+					this.batchWriteUnprocessedItem(op, {
+						type: "transient_error",
+						message: err instanceof Error ? err.message : String(err),
+					}),
+				);
+			}
+		}
+
+		const meta = this.partitionMeta(pCtx, { rowsRead, rowsWritten, forwardCount: 0 });
+		return {
+			processedItems,
+			unprocessedItems,
+			meta,
+			partitionMetas: req.operations.length > 0 ? [meta] : [],
+		};
+	}
+
+	private batchWriteUnprocessedItem(
+		op: BatchWriteRpcOperation,
+		reason: BatchRetryableFailure,
+	): BatchWriteItemsRpcResult["unprocessedItems"][number] {
+		return { inputIndex: op.inputIndex, operation: op.operation, item: this.publicItemKey(op), reason };
+	}
+
+	private publicItemKey(item: { hashKey: KeyBytes; sortKey: KeyBytes }): ItemKey {
+		return {
+			hashKey: KeyCodec.decode(item.hashKey),
+			sortKey: item.sortKey.byteLength === 0 ? undefined : KeyCodec.decode(item.sortKey),
+		};
+	}
+
+	private partitionMeta(
+		pCtx: PartitionContextResolved,
+		opts: { rowsRead: number; rowsWritten: number; forwardCount: number },
+	): OperationMetrics & PartitionInfo {
+		return {
+			rowsRead: opts.rowsRead,
+			rowsWritten: opts.rowsWritten,
 			databaseSize: this.#store.databaseSize,
 			servedByActorId: this.ctx.id.toString(),
 			servedByActorName: pCtx.doName,
 			servedByPartitionId: pCtx.partitionId,
-			forwardCount: 0,
+			forwardCount: opts.forwardCount,
 			hashDepth: isHashPartition(pCtx) ? PartitionIdHelper.depth(this.pCtx()._partitionIdBytes!) : 0,
 		};
+	}
+
+	private readItemLocally(pCtx: PartitionContextResolved, opts: GetItemOptions): GetItemResult {
+		const res = this.#store.getItem(PartitionDO.keyIn(opts.hashKey), PartitionDO.optKeyIn(opts.sortKey));
+		const { rowsRead, rowsWritten } = res;
+		const result = res.row;
+		const actorMeta = this.partitionMeta(pCtx, { rowsRead, rowsWritten, forwardCount: 0 });
 		const itemKey = { hashKey: opts.hashKey, sortKey: opts.sortKey };
 		if (!result) {
 			return { found: false, item: itemKey, meta: actorMeta };

--- a/apps/fokos-svc/src/lib/do-partition.ts
+++ b/apps/fokos-svc/src/lib/do-partition.ts
@@ -9,12 +9,12 @@ import {
 	PartitionInfo,
 	PutItemOptions,
 	PutItemResult,
+	BatchRetryableFailureReason,
 } from "./types.js";
 import type {
 	BatchGetItemsRpcRequest,
 	BatchGetItemsRpcResult,
 	BatchGetRpcItem,
-	BatchRetryableFailure,
 	BatchWriteItemsRpcRequest,
 	BatchWriteItemsRpcResult,
 	BatchWriteRpcOperation,
@@ -1576,7 +1576,10 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 		};
 	}
 
-	private batchGetUnprocessedKey(item: BatchGetRpcItem, reason: BatchRetryableFailure): BatchGetItemsRpcResult["unprocessedKeys"][number] {
+	private batchGetUnprocessedKey(
+		item: BatchGetRpcItem,
+		reason: BatchRetryableFailureReason,
+	): BatchGetItemsRpcResult["unprocessedKeys"][number] {
 		return { inputIndex: item.inputIndex, item: this.publicItemKey(item), reason };
 	}
 
@@ -1698,7 +1701,7 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 
 	private batchWriteUnprocessedItem(
 		op: BatchWriteRpcOperation,
-		reason: BatchRetryableFailure,
+		reason: BatchRetryableFailureReason,
 	): BatchWriteItemsRpcResult["unprocessedItems"][number] {
 		return { inputIndex: op.inputIndex, operation: op.operation, item: this.publicItemKey(op), reason };
 	}

--- a/apps/fokos-svc/src/lib/do-partition.ts
+++ b/apps/fokos-svc/src/lib/do-partition.ts
@@ -318,7 +318,7 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 					hk: hashKey,
 					sk: sortKey,
 					data: opts.data,
-					ttlEpochUtcSeconds: opts.ttlEpochUTCSeconds ?? null,
+					ttlEpochUtcSeconds: PartitionDO.resolveTtlEpochSeconds(opts),
 					lastTransactionTs: Date.now(),
 				});
 				const { rowsRead, rowsWritten } = conditionRes ? sumSqlMetrics(conditionRes, writeRes) : writeRes;
@@ -1304,6 +1304,16 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 		return k === undefined ? KeyCodec.encodeOptional(undefined) : PartitionDO.keyIn(k);
 	}
 
+	// Resolve a write's TTL to an absolute epoch (seconds). An explicit `ttlEpochUTCSeconds` wins;
+	// otherwise a relative `ttlSeconds` is anchored to write time. Returns null when neither is set.
+	// The HTTP layer already rejects setting both. Shared by putItem and batchWriteItems so a
+	// caller-supplied `ttlSeconds` is honored rather than silently dropped.
+	private static resolveTtlEpochSeconds(opts: { ttlSeconds?: number; ttlEpochUTCSeconds?: number }): number | null {
+		if (opts.ttlEpochUTCSeconds != null) return opts.ttlEpochUTCSeconds;
+		if (opts.ttlSeconds != null) return Math.floor(Date.now() / 1000) + opts.ttlSeconds;
+		return null;
+	}
+
 	private pCtx(): PartitionContextResolved {
 		invariant(
 			this.#_partitionContext,
@@ -1662,7 +1672,7 @@ export class PartitionDO extends DurableObject implements PartitionAPI {
 						hk: hashKey,
 						sk: sortKey,
 						data: op.data,
-						ttlEpochUtcSeconds: op.ttlEpochUTCSeconds ?? null,
+						ttlEpochUtcSeconds: PartitionDO.resolveTtlEpochSeconds(op),
 						lastTransactionTs: Date.now(),
 					});
 					rowsRead += writeRes.rowsRead;

--- a/apps/fokos-svc/src/lib/fokos-std.test.ts
+++ b/apps/fokos-svc/src/lib/fokos-std.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import { FokosStd } from "./fokos-std.js";
+import { MAX_BATCH_FORWARDED_SUB_BATCH_BYTES, MAX_BATCH_GET_ITEMS, MAX_BATCH_WRITE_ITEMS } from "./transaction-limits.js";
+import type {
+	BatchGetItemsOptions,
+	BatchGetItemsResult,
+	BatchWriteItemOperation,
+	BatchWriteItemsOptions,
+	BatchWriteItemsResult,
+	DeleteItemOptions,
+	DeleteItemResult,
+	FokosDBAPI,
+	GetItemOptions,
+	GetItemResult,
+	ItemKey,
+	OperationMetrics,
+	PartitionInfo,
+	PutItemOptions,
+	PutItemResult,
+} from "./types.js";
+
+type PartitionMeta = OperationMetrics & PartitionInfo;
+
+class FakeDB implements FokosDBAPI {
+	batchGetCalls: BatchGetItemsOptions[] = [];
+	batchWriteCalls: BatchWriteItemsOptions[] = [];
+	#batchGetHandler: (opts: BatchGetItemsOptions, callIndex: number) => Promise<BatchGetItemsResult>;
+	#batchWriteHandler: (opts: BatchWriteItemsOptions, callIndex: number) => Promise<BatchWriteItemsResult>;
+
+	constructor(opts: {
+		batchGetItems?: (opts: BatchGetItemsOptions, callIndex: number) => Promise<BatchGetItemsResult>;
+		batchWriteItems?: (opts: BatchWriteItemsOptions, callIndex: number) => Promise<BatchWriteItemsResult>;
+	}) {
+		this.#batchGetHandler =
+			opts.batchGetItems ?? (async () => ({ items: [], unprocessedKeys: [], meta: batchMeta(0, 0, 0), partitionMetas: [] }));
+		this.#batchWriteHandler =
+			opts.batchWriteItems ?? (async () => ({ processedItems: [], unprocessedItems: [], meta: batchMeta(0, 0, 0), partitionMetas: [] }));
+	}
+
+	async batchGetItems(opts: BatchGetItemsOptions): Promise<BatchGetItemsResult> {
+		const callIndex = this.batchGetCalls.length;
+		this.batchGetCalls.push(opts);
+		return this.#batchGetHandler(opts, callIndex);
+	}
+
+	async batchWriteItems(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult> {
+		const callIndex = this.batchWriteCalls.length;
+		this.batchWriteCalls.push(opts);
+		return this.#batchWriteHandler(opts, callIndex);
+	}
+
+	putItem(_opts: PutItemOptions): Promise<PutItemResult> {
+		throw new Error("unused");
+	}
+
+	getItem(_opts: GetItemOptions): Promise<GetItemResult> {
+		throw new Error("unused");
+	}
+
+	deleteItem(_opts: DeleteItemOptions): Promise<DeleteItemResult> {
+		throw new Error("unused");
+	}
+}
+
+describe("FokosStd batch helpers", () => {
+	it("batchGetAll chunks over native item-count limits and preserves global inputIndex values", async () => {
+		const items = Array.from({ length: MAX_BATCH_GET_ITEMS + 1 }, (_, index) => ({ hashKey: `get-${index}` }));
+		const db = new FakeDB({
+			batchGetItems: async (opts, callIndex) => {
+				return {
+					items: opts.items.map((item, inputIndex) => ({
+						inputIndex,
+						found: true,
+						item: { ...item, data: `data-${item.hashKey}`, version: 1 },
+					})),
+					unprocessedKeys: [],
+					meta: batchMeta(opts.items.length, opts.items.length, 0, { rowsRead: opts.items.length }),
+					partitionMetas: [partitionMeta(`get-${callIndex}`, { rowsRead: opts.items.length })],
+				};
+			},
+		});
+
+		const result = await new FokosStd(db, noWaitOptions()).batchGetAll({ items });
+
+		expect(db.batchGetCalls.map((call) => call.items.length)).toEqual([MAX_BATCH_GET_ITEMS, 1]);
+		expect(result.items.map((item) => item.inputIndex)).toEqual(items.map((_, index) => index));
+		expect(result.unprocessedKeys).toEqual([]);
+		expect(result.meta).toEqual({
+			requestedCount: items.length,
+			processedCount: items.length,
+			unprocessedCount: 0,
+			rowsRead: items.length,
+			rowsWritten: 0,
+			forwardCount: 0,
+			partitionsVisited: 2,
+		});
+		expect(result.partitionMetas.map((meta) => meta.servedByActorName)).toEqual(["get-0", "get-1"]);
+	});
+
+	it("batchGetAll retries unprocessed keys and remaps retry-local indexes to original indexes", async () => {
+		const sleeps: number[] = [];
+		const db = new FakeDB({
+			batchGetItems: async (opts, callIndex) => {
+				if (callIndex === 0) {
+					return {
+						items: [
+							{ inputIndex: 0, found: true, item: { ...opts.items[0], data: "first", version: 1 } },
+							{ inputIndex: 1, found: true, item: { ...opts.items[1], data: "second", version: 1 } },
+						],
+						unprocessedKeys: [{ inputIndex: 2, item: opts.items[2], reason: { type: "transient_error", message: "retry me" } }],
+						meta: batchMeta(3, 2, 1, { rowsRead: 2, forwardCount: 1 }),
+						partitionMetas: [partitionMeta("get-first", { rowsRead: 2, forwardCount: 1 })],
+					};
+				}
+				return {
+					items: [{ inputIndex: 0, found: true, item: { ...opts.items[0], data: "third", version: 1 } }],
+					unprocessedKeys: [],
+					meta: batchMeta(1, 1, 0, { rowsRead: 1 }),
+					partitionMetas: [partitionMeta("get-retry", { rowsRead: 1 })],
+				};
+			},
+		});
+
+		const result = await new FokosStd(db, noWaitOptions(sleeps)).batchGetAll({
+			items: [{ hashKey: "first" }, { hashKey: "second" }, { hashKey: "third" }],
+		});
+
+		expect(sleeps).toEqual([10]);
+		expect(db.batchGetCalls.map((call) => call.items.map((item) => item.hashKey))).toEqual([["first", "second", "third"], ["third"]]);
+		expect(result.items.map((item) => item.inputIndex)).toEqual([0, 1, 2]);
+		expect(result.unprocessedKeys).toEqual([]);
+		expect(result.meta).toMatchObject({ requestedCount: 3, processedCount: 3, unprocessedCount: 0, rowsRead: 3, forwardCount: 1 });
+		expect(result.partitionMetas.map((meta) => meta.servedByActorName)).toEqual(["get-first", "get-retry"]);
+	});
+
+	it("batchGetAll leaves exhausted unprocessed keys at their original indexes", async () => {
+		const db = new FakeDB({
+			batchGetItems: async (opts, callIndex) => ({
+				items:
+					callIndex === 0
+						? [
+								{ inputIndex: 0, found: true, item: { ...opts.items[0], data: "first", version: 1 } },
+								{ inputIndex: 1, found: true, item: { ...opts.items[1], data: "second", version: 1 } },
+							]
+						: [],
+				unprocessedKeys: [
+					{
+						inputIndex: callIndex === 0 ? 2 : 0,
+						item: callIndex === 0 ? opts.items[2] : opts.items[0],
+						reason: { type: "transient_error", message: `still retrying ${callIndex}` },
+					},
+				],
+				meta: batchMeta(opts.items.length, callIndex === 0 ? 2 : 0, 1, { rowsRead: callIndex === 0 ? 2 : 0 }),
+				partitionMetas: [partitionMeta(`get-${callIndex}`, { rowsRead: callIndex === 0 ? 2 : 0 })],
+			}),
+		});
+
+		const result = await new FokosStd(db, noWaitOptions()).batchGetAll({
+			items: [{ hashKey: "first" }, { hashKey: "second" }, { hashKey: "third" }],
+		});
+
+		expect(db.batchGetCalls).toHaveLength(2);
+		expect(result.items.map((item) => item.inputIndex)).toEqual([0, 1]);
+		expect(result.unprocessedKeys).toEqual([
+			{ inputIndex: 2, item: { hashKey: "third" }, reason: { type: "transient_error", message: "still retrying 1" } },
+		]);
+		expect(result.meta).toMatchObject({ requestedCount: 3, processedCount: 2, unprocessedCount: 1, rowsRead: 2, partitionsVisited: 2 });
+	});
+
+	it("batchGetAll retries retryable thrown batch calls only", async () => {
+		const retryable = Object.assign(new Error("temporary rpc failure"), { retryable: true });
+		const db = new FakeDB({
+			batchGetItems: async (opts, callIndex) => {
+				if (callIndex === 0) throw retryable;
+				return {
+					items: [{ inputIndex: 0, found: true, item: { ...opts.items[0], data: "ok", version: 1 } }],
+					unprocessedKeys: [],
+					meta: batchMeta(1, 1, 0, { rowsRead: 1 }),
+					partitionMetas: [partitionMeta("after-throw", { rowsRead: 1 })],
+				};
+			},
+		});
+
+		const result = await new FokosStd(db, noWaitOptions()).batchGetAll({ items: [{ hashKey: "retryable" }] });
+
+		expect(db.batchGetCalls).toHaveLength(2);
+		expect(result.items).toHaveLength(1);
+		expect(result.unprocessedKeys).toEqual([]);
+
+		const hardFailure = new FakeDB({
+			batchGetItems: async () => {
+				throw new Error("not retryable");
+			},
+		});
+		await expect(new FokosStd(hardFailure, noWaitOptions()).batchGetAll({ items: [{ hashKey: "hard" }] })).rejects.toThrow(/not retryable/);
+		expect(hardFailure.batchGetCalls).toHaveLength(1);
+	});
+
+	it("batchWriteAll chunks, retries unprocessed items, and does not add versions", async () => {
+		const operations = Array.from({ length: MAX_BATCH_WRITE_ITEMS + 1 }, (_, index) => ({
+			operation: "put" as const,
+			hashKey: `write-${index}`,
+			data: `data-${index}`,
+		}));
+		const db = new FakeDB({
+			batchWriteItems: async (opts, callIndex) => {
+				if (callIndex === 0) {
+					return {
+						processedItems: opts.operations.slice(0, -1).map((operation, inputIndex) => ({
+							inputIndex,
+							operation: operation.operation,
+							item: { hashKey: operation.hashKey, sortKey: operation.sortKey },
+						})),
+						unprocessedItems: [
+							{
+								inputIndex: MAX_BATCH_WRITE_ITEMS - 1,
+								operation: "put",
+								item: { hashKey: `write-${MAX_BATCH_WRITE_ITEMS - 1}` },
+								reason: { type: "pending_lock", conflictingTransactionId: "tx-1" },
+							},
+						],
+						meta: batchMeta(MAX_BATCH_WRITE_ITEMS, MAX_BATCH_WRITE_ITEMS - 1, 1, { rowsWritten: MAX_BATCH_WRITE_ITEMS - 1 }),
+						partitionMetas: [partitionMeta("write-first", { rowsWritten: MAX_BATCH_WRITE_ITEMS - 1 })],
+					};
+				}
+				return {
+					processedItems: opts.operations.map((operation, inputIndex) => ({
+						inputIndex,
+						operation: operation.operation,
+						item: { hashKey: operation.hashKey, sortKey: operation.sortKey },
+					})),
+					unprocessedItems: [],
+					meta: batchMeta(opts.operations.length, opts.operations.length, 0, { rowsWritten: opts.operations.length }),
+					partitionMetas: [partitionMeta(`write-${callIndex}`, { rowsWritten: opts.operations.length })],
+				};
+			},
+		});
+
+		const result = await new FokosStd(db, noWaitOptions()).batchWriteAll({ operations });
+
+		expect(db.batchWriteCalls.map((call) => call.operations.map((operation) => operation.hashKey))).toEqual([
+			Array.from({ length: MAX_BATCH_WRITE_ITEMS }, (_, index) => `write-${index}`),
+			[`write-${MAX_BATCH_WRITE_ITEMS}`],
+			[`write-${MAX_BATCH_WRITE_ITEMS - 1}`],
+		]);
+		expect(result.processedItems.map((item) => item.inputIndex)).toEqual(operations.map((_, index) => index));
+		expect(result.processedItems.some((item) => "version" in item)).toBe(false);
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.meta).toEqual({
+			requestedCount: operations.length,
+			processedCount: operations.length,
+			unprocessedCount: 0,
+			rowsRead: 0,
+			rowsWritten: operations.length,
+			forwardCount: 0,
+			partitionsVisited: 3,
+		});
+		expect(result.partitionMetas.map((meta) => meta.servedByActorName)).toEqual(["write-first", "write-1", "write-2"]);
+	});
+
+	it("batchWriteAll chunks by native payload byte limit before calling the core API", async () => {
+		const data = new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES - 128);
+		const operations = Array.from({ length: 5 }, (_, index) => ({
+			operation: "put" as const,
+			hashKey: `large-write-${index}`,
+			data,
+		}));
+		const db = new FakeDB({
+			batchWriteItems: async (opts, callIndex) => ({
+				processedItems: opts.operations.map((operation, inputIndex) => ({
+					inputIndex,
+					operation: operation.operation,
+					item: { hashKey: operation.hashKey, sortKey: operation.sortKey },
+				})),
+				unprocessedItems: [],
+				meta: batchMeta(opts.operations.length, opts.operations.length, 0, { rowsWritten: opts.operations.length }),
+				partitionMetas: [partitionMeta(`large-write-${callIndex}`, { rowsWritten: opts.operations.length })],
+			}),
+		});
+
+		const result = await new FokosStd(db, noWaitOptions()).batchWriteAll({ operations });
+
+		expect(db.batchWriteCalls.map((call) => call.operations.length)).toEqual([4, 1]);
+		expect(result.processedItems.map((item) => item.inputIndex)).toEqual([0, 1, 2, 3, 4]);
+		expect(result.meta).toMatchObject({ requestedCount: 5, processedCount: 5, unprocessedCount: 0, rowsWritten: 5, partitionsVisited: 2 });
+		expect(result.partitionMetas.map((meta) => meta.servedByActorName)).toEqual(["large-write-0", "large-write-1"]);
+	});
+
+	it("rejects duplicate keys across the full logical request before chunking", async () => {
+		const db = new FakeDB({});
+		const getItems = Array.from({ length: MAX_BATCH_GET_ITEMS + 1 }, (_, index) => ({ hashKey: `get-dupe-${index}` }));
+		getItems[MAX_BATCH_GET_ITEMS] = { hashKey: "get-dupe-0" };
+
+		await expect(new FokosStd(db, noWaitOptions()).batchGetAll({ items: getItems })).rejects.toThrow(/batchGetItems duplicate key/);
+		expect(db.batchGetCalls).toEqual([]);
+
+		const operations: BatchWriteItemOperation[] = Array.from({ length: MAX_BATCH_WRITE_ITEMS + 1 }, (_, index) => ({
+			operation: "put" as const,
+			hashKey: `write-dupe-${index}`,
+			data: "x",
+		}));
+		operations[MAX_BATCH_WRITE_ITEMS] = { operation: "delete", hashKey: "write-dupe-0" };
+
+		await expect(new FokosStd(db, noWaitOptions()).batchWriteAll({ operations })).rejects.toThrow(/batchWriteItems duplicate key/);
+		expect(db.batchWriteCalls).toEqual([]);
+	});
+});
+
+function noWaitOptions(sleeps: number[] = []) {
+	return {
+		maxAttempts: 2,
+		baseDelayMs: 10,
+		maxDelayMs: 100,
+		random: () => 1,
+		sleep: async (delayMs: number) => {
+			sleeps.push(delayMs);
+		},
+	};
+}
+
+function batchMeta(
+	requestedCount: number,
+	processedCount: number,
+	unprocessedCount: number,
+	work: Partial<Pick<BatchGetItemsResult["meta"], "rowsRead" | "rowsWritten" | "forwardCount">> = {},
+): BatchGetItemsResult["meta"] {
+	return {
+		requestedCount,
+		processedCount,
+		unprocessedCount,
+		rowsRead: work.rowsRead ?? 0,
+		rowsWritten: work.rowsWritten ?? 0,
+		forwardCount: work.forwardCount ?? 0,
+		partitionsVisited: 1,
+	};
+}
+
+function partitionMeta(
+	servedByActorName: string,
+	work: Partial<Pick<PartitionMeta, "rowsRead" | "rowsWritten" | "forwardCount">> = {},
+): PartitionMeta {
+	return {
+		rowsRead: work.rowsRead ?? 0,
+		rowsWritten: work.rowsWritten ?? 0,
+		databaseSize: 1024,
+		servedByActorId: `actor-${servedByActorName}`,
+		servedByActorName,
+		servedByPartitionId: `partition-${servedByActorName}`,
+		forwardCount: work.forwardCount ?? 0,
+		hashDepth: 0,
+	};
+}

--- a/apps/fokos-svc/src/lib/fokos-std.ts
+++ b/apps/fokos-svc/src/lib/fokos-std.ts
@@ -1,0 +1,346 @@
+import { isErrorRetryable } from "durable-utils/do-utils";
+import {
+	encodedPairIdentity,
+	estimateEncodedKeyPayloadBytes,
+	keyForError,
+	MAX_BATCH_GET_ITEMS,
+	MAX_BATCH_PAYLOAD_BYTES,
+	MAX_BATCH_WRITE_ITEMS,
+	payloadBytes,
+	validateBatchGetItems,
+	validateBatchWriteOperations,
+} from "./transaction-limits.js";
+import type {
+	BatchGetItemsOptions,
+	BatchGetItemsResult,
+	BatchGetProcessedItem,
+	BatchGetUnprocessedKey,
+	BatchItemsMeta,
+	BatchWriteItemOperation,
+	BatchWriteItemsOptions,
+	BatchWriteItemsResult,
+	BatchWriteProcessedItem,
+	BatchWriteUnprocessedItem,
+	FokosDBAPI,
+	ItemKey,
+	OperationMetrics,
+	PartitionInfo,
+} from "./types.js";
+
+export type FokosStdOptions = {
+	maxAttempts?: number;
+	baseDelayMs?: number;
+	maxDelayMs?: number;
+	sleep?: (delayMs: number) => Promise<void>;
+	random?: () => number;
+	isRetryableError?: (error: unknown) => boolean;
+};
+
+type BatchGetPending = {
+	inputIndex: number;
+	item: ItemKey;
+	reason?: BatchGetUnprocessedKey["reason"];
+};
+
+type BatchWritePending = {
+	inputIndex: number;
+	operation: BatchWriteItemOperation;
+	reason?: BatchWriteUnprocessedItem["reason"];
+};
+
+type FokosStdResolvedOptions = Required<FokosStdOptions>;
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 25;
+const DEFAULT_MAX_DELAY_MS = 1_000;
+
+export class FokosStd {
+	#db: FokosDBAPI;
+	#options: FokosStdResolvedOptions;
+
+	constructor(db: FokosDBAPI, options: FokosStdOptions = {}) {
+		const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+		if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1) {
+			throw new Error("fokos/std: maxAttempts must be an integer greater or equal to 1");
+		}
+		const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+		const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+		if (!Number.isFinite(baseDelayMs) || baseDelayMs < 0) {
+			throw new Error("fokos/std: baseDelayMs must be a finite non-negative number");
+		}
+		if (!Number.isFinite(maxDelayMs) || maxDelayMs < 0) {
+			throw new Error("fokos/std: maxDelayMs must be a finite non-negative number");
+		}
+		this.#db = db;
+		this.#options = {
+			maxAttempts,
+			baseDelayMs,
+			maxDelayMs,
+			sleep: options.sleep ?? defaultSleep,
+			random: options.random ?? Math.random,
+			isRetryableError: options.isRetryableError ?? isErrorRetryable,
+		};
+	}
+
+	async batchGetAll(opts: BatchGetItemsOptions): Promise<BatchGetItemsResult> {
+		validateBatchGetAllInput(opts.items);
+		let pending: BatchGetPending[] = opts.items.map((item, inputIndex) => ({ inputIndex, item }));
+		const items: BatchGetProcessedItem[] = [];
+		const partitionMetas: Array<OperationMetrics & PartitionInfo> = [];
+		const work = emptyWorkMeta(opts.items.length);
+
+		for (let attempt = 1; attempt <= this.#options.maxAttempts && pending.length > 0; attempt++) {
+			const nextPending: BatchGetPending[] = [];
+			for (const chunk of chunkBatchGetPending(pending)) {
+				const localItems = chunk.map((entry) => entry.item);
+				try {
+					const result = await this.#db.batchGetItems({ items: localItems });
+					addWork(work, result.meta);
+					partitionMetas.push(...result.partitionMetas);
+					for (const item of result.items) {
+						const entry = chunk[item.inputIndex];
+						items.push(remapBatchGetProcessedItem(item, entry));
+					}
+					for (const item of result.unprocessedKeys) {
+						const entry = chunk[item.inputIndex];
+						nextPending.push({ inputIndex: entry.inputIndex, item: entry.item, reason: item.reason });
+					}
+				} catch (error) {
+					if (!this.#options.isRetryableError(error)) throw error;
+					const reason = retryableErrorReason(error);
+					nextPending.push(...chunk.map((entry) => ({ ...entry, reason })));
+				}
+			}
+			pending = nextPending;
+			if (pending.length > 0 && attempt < this.#options.maxAttempts) {
+				await this.#options.sleep(this.#backoffDelayMs(attempt));
+			}
+		}
+
+		items.sort(compareInputIndex);
+		const unprocessedKeys = pending.map((entry) => batchGetUnprocessedFromPending(entry)).sort(compareInputIndex);
+		return {
+			items,
+			unprocessedKeys,
+			meta: finalizeMeta(work, opts.items.length, items.length, unprocessedKeys.length, partitionMetas.length),
+			partitionMetas,
+		};
+	}
+
+	async batchWriteAll(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult> {
+		validateBatchWriteAllInput(opts.operations);
+		let pending: BatchWritePending[] = opts.operations.map((operation, inputIndex) => ({ inputIndex, operation }));
+		const processedItems: BatchWriteProcessedItem[] = [];
+		const partitionMetas: Array<OperationMetrics & PartitionInfo> = [];
+		const work = emptyWorkMeta(opts.operations.length);
+
+		for (let attempt = 1; attempt <= this.#options.maxAttempts && pending.length > 0; attempt++) {
+			const nextPending: BatchWritePending[] = [];
+			for (const chunk of chunkBatchWritePending(pending)) {
+				const operations = chunk.map((entry) => entry.operation);
+				try {
+					const result = await this.#db.batchWriteItems({ operations });
+					addWork(work, result.meta);
+					partitionMetas.push(...result.partitionMetas);
+					for (const item of result.processedItems) {
+						const entry = chunk[item.inputIndex];
+						processedItems.push(remapBatchWriteProcessedItem(item, entry));
+					}
+					// Retry only entries the core reported unprocessed. Retrying writes is safe
+					// but not version-idempotent: a re-applied put/delete can bump versions again.
+					for (const item of result.unprocessedItems) {
+						const entry = chunk[item.inputIndex];
+						nextPending.push({ inputIndex: entry.inputIndex, operation: entry.operation, reason: item.reason });
+					}
+				} catch (error) {
+					if (!this.#options.isRetryableError(error)) throw error;
+					const reason = retryableErrorReason(error);
+					nextPending.push(...chunk.map((entry) => ({ ...entry, reason })));
+				}
+			}
+			pending = nextPending;
+			if (pending.length > 0 && attempt < this.#options.maxAttempts) {
+				await this.#options.sleep(this.#backoffDelayMs(attempt));
+			}
+		}
+
+		processedItems.sort(compareInputIndex);
+		const unprocessedItems = pending.map((entry) => batchWriteUnprocessedFromPending(entry)).sort(compareInputIndex);
+		return {
+			processedItems,
+			unprocessedItems,
+			meta: finalizeMeta(work, opts.operations.length, processedItems.length, unprocessedItems.length, partitionMetas.length),
+			// Ordered visit trail across chunks and retries. This intentionally is not de-duplicated:
+			// retry work and multi-chunk work are operationally meaningful to callers.
+			partitionMetas,
+		};
+	}
+
+	#backoffDelayMs(attempt: number): number {
+		const cap = Math.min(this.#options.maxDelayMs, this.#options.baseDelayMs * 2 ** (attempt - 1));
+		const random = this.#options.random();
+		const jitter = Number.isFinite(random) ? Math.max(0, Math.min(1, random)) : 0;
+		return Math.floor(cap * jitter);
+	}
+}
+
+function validateBatchGetAllInput(items: readonly ItemKey[]): void {
+	const seen = new Set<string>();
+	for (const item of items) {
+		validateBatchGetItems([item]);
+		const identity = encodedPairIdentity(item);
+		if (seen.has(identity)) {
+			const { hashKey, sortKey } = keyForError(item);
+			throw new Error(`fokos: batchGetItems duplicate key (${hashKey}, ${sortKey})`);
+		}
+		seen.add(identity);
+	}
+	if (items.length === 0) {
+		validateBatchGetItems(items);
+	}
+}
+
+function validateBatchWriteAllInput(operations: readonly BatchWriteItemOperation[]): void {
+	const seen = new Set<string>();
+	for (const operation of operations) {
+		validateBatchWriteOperations([operation]);
+		const identity = encodedPairIdentity(operation);
+		if (seen.has(identity)) {
+			const { hashKey, sortKey } = keyForError(operation);
+			throw new Error(`fokos: batchWriteItems duplicate key (${hashKey}, ${sortKey})`);
+		}
+		seen.add(identity);
+	}
+	if (operations.length === 0) {
+		validateBatchWriteOperations(operations);
+	}
+}
+
+function chunkBatchGetPending(pending: readonly BatchGetPending[]): BatchGetPending[][] {
+	return chunkByLimits(pending, MAX_BATCH_GET_ITEMS, (entry) => batchGetPayloadBytes(entry.item));
+}
+
+function chunkBatchWritePending(pending: readonly BatchWritePending[]): BatchWritePending[][] {
+	return chunkByLimits(pending, MAX_BATCH_WRITE_ITEMS, (entry) => batchWritePayloadBytes(entry.operation));
+}
+
+function chunkByLimits<T>(entries: readonly T[], maxCount: number, bytesForEntry: (entry: T) => number): T[][] {
+	const chunks: T[][] = [];
+	let current: T[] = [];
+	let currentBytes = 0;
+	const flush = () => {
+		if (current.length === 0) return;
+		chunks.push(current);
+		current = [];
+		currentBytes = 0;
+	};
+
+	for (const entry of entries) {
+		const entryBytes = bytesForEntry(entry);
+		if (entryBytes > MAX_BATCH_PAYLOAD_BYTES) {
+			throw new Error(`fokos/std: single batch entry exceeds ${MAX_BATCH_PAYLOAD_BYTES / (1024 * 1024)} MB payload limit`);
+		}
+		if (current.length >= maxCount || (current.length > 0 && currentBytes + entryBytes > MAX_BATCH_PAYLOAD_BYTES)) {
+			flush();
+		}
+		current.push(entry);
+		currentBytes += entryBytes;
+	}
+	flush();
+	return chunks;
+}
+
+function batchGetPayloadBytes(item: ItemKey): number {
+	return estimateEncodedKeyPayloadBytes(item);
+}
+
+function batchWritePayloadBytes(operation: BatchWriteItemOperation): number {
+	return estimateEncodedKeyPayloadBytes(operation) + payloadBytes(operation.operation === "put" ? operation.data : undefined);
+}
+
+function remapBatchGetProcessedItem(item: BatchGetProcessedItem, entry: BatchGetPending): BatchGetProcessedItem {
+	if (!item.found) {
+		return { inputIndex: entry.inputIndex, found: false, item: entry.item };
+	}
+	return {
+		inputIndex: entry.inputIndex,
+		found: true,
+		item: { ...item.item, hashKey: entry.item.hashKey, sortKey: entry.item.sortKey },
+	};
+}
+
+function remapBatchWriteProcessedItem(item: BatchWriteProcessedItem, entry: BatchWritePending): BatchWriteProcessedItem {
+	return {
+		inputIndex: entry.inputIndex,
+		operation: item.operation,
+		item: { hashKey: entry.operation.hashKey, sortKey: entry.operation.sortKey },
+	};
+}
+
+function batchGetUnprocessedFromPending(entry: BatchGetPending): BatchGetUnprocessedKey {
+	return {
+		inputIndex: entry.inputIndex,
+		item: entry.item,
+		reason: entry.reason ?? { type: "transient_error", message: "fokos/std: retry attempts exhausted" },
+	};
+}
+
+function batchWriteUnprocessedFromPending(entry: BatchWritePending): BatchWriteUnprocessedItem {
+	return {
+		inputIndex: entry.inputIndex,
+		operation: entry.operation.operation,
+		item: { hashKey: entry.operation.hashKey, sortKey: entry.operation.sortKey },
+		reason: entry.reason ?? { type: "transient_error", message: "fokos/std: retry attempts exhausted" },
+	};
+}
+
+function retryableErrorReason(error: unknown): BatchGetUnprocessedKey["reason"] {
+	return {
+		type: "transient_error",
+		message: error instanceof Error ? error.message : String(error),
+	};
+}
+
+function emptyWorkMeta(requestedCount: number): BatchItemsMeta {
+	return {
+		requestedCount,
+		processedCount: 0,
+		unprocessedCount: requestedCount,
+		rowsRead: 0,
+		rowsWritten: 0,
+		forwardCount: 0,
+		partitionsVisited: 0,
+	};
+}
+
+function addWork(target: BatchItemsMeta, source: BatchItemsMeta): void {
+	target.rowsRead += source.rowsRead;
+	target.rowsWritten += source.rowsWritten;
+	target.forwardCount += source.forwardCount;
+}
+
+function finalizeMeta(
+	work: BatchItemsMeta,
+	requestedCount: number,
+	processedCount: number,
+	unprocessedCount: number,
+	partitionsVisited: number,
+): BatchItemsMeta {
+	return {
+		requestedCount,
+		processedCount,
+		unprocessedCount,
+		rowsRead: work.rowsRead,
+		rowsWritten: work.rowsWritten,
+		forwardCount: work.forwardCount,
+		partitionsVisited,
+	};
+}
+
+function compareInputIndex<T extends { inputIndex: number }>(a: T, b: T): number {
+	return a.inputIndex - b.inputIndex;
+}
+
+function defaultSleep(delayMs: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, delayMs));
+}

--- a/apps/fokos-svc/src/lib/fokos-std.ts
+++ b/apps/fokos-svc/src/lib/fokos-std.ts
@@ -127,6 +127,10 @@ export class FokosStd {
 		};
 	}
 
+	/**
+	 * Retries only writes returned as unprocessed. This is safe for partial failure recovery,
+	 * but not version-idempotent: a retried put/delete can bump item versions.
+	 */
 	async batchWriteAll(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult> {
 		validateBatchWriteAllInput(opts.operations);
 		let pending: BatchWritePending[] = opts.operations.map((operation, inputIndex) => ({ inputIndex, operation }));
@@ -146,8 +150,6 @@ export class FokosStd {
 						const entry = chunk[item.inputIndex];
 						processedItems.push(remapBatchWriteProcessedItem(item, entry));
 					}
-					// Retry only entries the core reported unprocessed. Retrying writes is safe
-					// but not version-idempotent: a re-applied put/delete can bump versions again.
 					for (const item of result.unprocessedItems) {
 						const entry = chunk[item.inputIndex];
 						nextPending.push({ inputIndex: entry.inputIndex, operation: entry.operation, reason: item.reason });

--- a/apps/fokos-svc/src/lib/transaction-limits.test.ts
+++ b/apps/fokos-svc/src/lib/transaction-limits.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
+	MAX_BATCH_GET_ITEMS,
+	MAX_BATCH_FORWARDED_SUB_BATCH_BYTES,
+	MAX_BATCH_PAYLOAD_BYTES,
+	MAX_BATCH_WRITE_ITEMS,
 	MAX_ITEMS_PER_TRANSACTION,
 	MAX_PAYLOAD_BYTES,
+	estimateBatchWriteForwardedOperationBytes,
+	estimateEncodedBatchWriteForwardedOperationBytes,
+	validateBatchGetItems,
+	validateBatchWriteOperations,
 	validateItemKeys,
 	validateTransactWriteOperations,
+	type BatchWriteOperationLike,
 	type TransactWriteOperationLike,
 } from "./transaction-limits.js";
+import { KeyCodec } from "./partition-topology/key-codec.js";
 
 function putOp(hashKey: string, sortKey?: string, data: Uint8Array | string = "x"): TransactWriteOperationLike {
+	return { hashKey, sortKey, operation: "put", data };
+}
+
+function batchPutOp(hashKey: string | Uint8Array, sortKey?: string | Uint8Array, data: Uint8Array | string = "x"): BatchWriteOperationLike {
 	return { hashKey, sortKey, operation: "put", data };
 }
 
@@ -100,5 +114,117 @@ describe("validateTransactWriteOperations", () => {
 		expect(() =>
 			validateTransactWriteOperations([putOp("a", undefined, half), putOp("b", undefined, half), putOp("c", undefined, "x")]),
 		).toThrow(/total payload exceeds 4 MB/);
+	});
+});
+
+describe("validateBatchGetItems", () => {
+	it("rejects an empty item list", () => {
+		expect(() => validateBatchGetItems([])).toThrow(/batchGetItems requires at least 1 item/);
+	});
+
+	it("accepts exactly the max item count and rejects one more", () => {
+		const items = Array.from({ length: MAX_BATCH_GET_ITEMS }, (_, i) => ({ hashKey: `hk-${i}` }));
+		expect(() => validateBatchGetItems(items)).not.toThrow();
+		expect(() => validateBatchGetItems([...items, { hashKey: "one-too-many" }])).toThrow(/batchGetItems supports at most 100 items/);
+	});
+
+	it("rejects duplicate keys, treating absent sortKey as the empty key", () => {
+		expect(() => validateBatchGetItems([{ hashKey: "a" }, { hashKey: "a" }])).toThrow(/batchGetItems duplicate key/);
+		expect(() =>
+			validateBatchGetItems([
+				{ hashKey: "a", sortKey: "s" },
+				{ hashKey: "a", sortKey: "s" },
+			]),
+		).toThrow(/batchGetItems duplicate key/);
+		expect(() => validateBatchGetItems([{ hashKey: "a" }, { hashKey: "a", sortKey: "s" }])).not.toThrow();
+	});
+
+	it("dedupes by encoded key bytes, not string coercion", () => {
+		expect(() => validateBatchGetItems([{ hashKey: "ÿ" }, { hashKey: new Uint8Array([0xff]) }])).not.toThrow();
+		expect(() =>
+			validateBatchGetItems([
+				{ hashKey: "a", sortKey: "ÿ" },
+				{ hashKey: "a", sortKey: new Uint8Array([0xff]) },
+			]),
+		).not.toThrow();
+	});
+
+	it("rejects oversized encoded key payloads", () => {
+		const largeKey = "x".repeat(MAX_BATCH_PAYLOAD_BYTES + 1);
+		expect(() => validateBatchGetItems([{ hashKey: largeKey }])).toThrow(/batchGetItems total payload exceeds 4 MB/);
+	});
+});
+
+describe("validateBatchWriteOperations", () => {
+	it("rejects an empty operation list", () => {
+		expect(() => validateBatchWriteOperations([])).toThrow(/batchWriteItems requires at least 1 item/);
+	});
+
+	it("accepts exactly the max item count and rejects one more", () => {
+		const ops = Array.from({ length: MAX_BATCH_WRITE_ITEMS }, (_, i) => batchPutOp(`hk-${i}`));
+		expect(() => validateBatchWriteOperations(ops)).not.toThrow();
+		expect(() => validateBatchWriteOperations([...ops, batchPutOp("one-too-many")])).toThrow(/batchWriteItems supports at most 25 items/);
+	});
+
+	it("rejects duplicate keys, treating absent sortKey as the empty key", () => {
+		expect(() => validateBatchWriteOperations([batchPutOp("a"), { hashKey: "a", operation: "delete" }])).toThrow(
+			/batchWriteItems duplicate key/,
+		);
+		expect(() => validateBatchWriteOperations([batchPutOp("a", "s"), { hashKey: "a", sortKey: "s", operation: "delete" }])).toThrow(
+			/batchWriteItems duplicate key/,
+		);
+		expect(() => validateBatchWriteOperations([batchPutOp("a"), batchPutOp("a", "s")])).not.toThrow();
+	});
+
+	it("dedupes by encoded key bytes, not string coercion", () => {
+		expect(() => validateBatchWriteOperations([batchPutOp("ÿ"), batchPutOp(new Uint8Array([0xff]))])).not.toThrow();
+		expect(() => validateBatchWriteOperations([batchPutOp("a", "ÿ"), batchPutOp("a", new Uint8Array([0xff]))])).not.toThrow();
+	});
+
+	it("rejects unsupported operations", () => {
+		expect(() => validateBatchWriteOperations([{ hashKey: "a", operation: "check" }])).toThrow(/operation must be "put" or "delete"/);
+	});
+
+	it("rejects conditions", () => {
+		expect(() => validateBatchWriteOperations([{ ...batchPutOp("a"), conditions: [{ type: "item_exists" }] }])).toThrow(
+			/does not support conditions/,
+		);
+	});
+
+	it("rejects a put without data", () => {
+		expect(() => validateBatchWriteOperations([{ hashKey: "a", operation: "put" }])).toThrow(/"put" operation requires data/);
+	});
+
+	it("rejects oversized encoded payloads", () => {
+		const belowForwardedLimit = new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES - 128);
+		expect(() =>
+			validateBatchWriteOperations(Array.from({ length: 5 }, (_, i) => batchPutOp(`hk-${i}`, undefined, belowForwardedLimit))),
+		).toThrow(/batchWriteItems total payload exceeds 4 MB/);
+	});
+
+	it("rejects a single operation that cannot fit in one forwarded sub-batch", () => {
+		expect(() =>
+			validateBatchWriteOperations([batchPutOp("fits", undefined, new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES - 128))]),
+		).not.toThrow();
+		expect(() =>
+			validateBatchWriteOperations([batchPutOp("too-large", undefined, new Uint8Array(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES + 1))]),
+		).toThrow(/batchWriteItems operation payload exceeds 1 MB forwarded sub-batch limit/);
+	});
+
+	it("uses the same forwarded byte estimate for raw public keys and encoded KeyBytes", () => {
+		const rawOp = {
+			operation: "put" as const,
+			hashKey: "hash",
+			sortKey: new Uint8Array([0xff]),
+			data: "é",
+			ttlSeconds: 10,
+		};
+		const encodedOp = {
+			...rawOp,
+			hashKey: KeyCodec.encode(rawOp.hashKey),
+			sortKey: KeyCodec.encodeOptional(rawOp.sortKey),
+		};
+
+		expect(estimateEncodedBatchWriteForwardedOperationBytes(encodedOp)).toBe(estimateBatchWriteForwardedOperationBytes(rawOp));
 	});
 });

--- a/apps/fokos-svc/src/lib/transaction-limits.ts
+++ b/apps/fokos-svc/src/lib/transaction-limits.ts
@@ -5,10 +5,17 @@
  */
 
 import type { TransactionOperationType } from "./transaction-types.js";
-import { KeyCodec } from "./partition-topology/key-codec.js";
+import { KeyCodec, type KeyBytes } from "./partition-topology/key-codec.js";
 
 export const MAX_ITEMS_PER_TRANSACTION = 100;
 export const MAX_PAYLOAD_BYTES = 4 * 1024 * 1024; // 4 MB
+export const MAX_BATCH_GET_ITEMS = 100;
+export const MAX_BATCH_WRITE_ITEMS = 25;
+export const MAX_BATCH_PAYLOAD_BYTES = 4 * 1024 * 1024; // 4 MB; conservative first native ceiling.
+// Single forwarded write ops reject in public validation; the DO-side guard defends internal chunks.
+export const MAX_BATCH_FORWARDED_SUB_BATCH_BYTES = 1024 * 1024; // 1 MB
+
+const batchWriteTextEncoder = new TextEncoder();
 
 /**
  * The minimal shape validation needs. Both TCWriteOperation (client/TC wire type) and the
@@ -21,8 +28,96 @@ export type TransactWriteOperationLike = {
 	data?: Uint8Array | string;
 };
 
+export type ItemKeyLike = {
+	hashKey: string | Uint8Array;
+	sortKey?: string | Uint8Array;
+};
+
+export type BatchWriteOperationLike = ItemKeyLike & {
+	operation: string;
+	data?: Uint8Array | string;
+	ttlSeconds?: number;
+	ttlEpochUTCSeconds?: number;
+	conditions?: unknown;
+};
+
+export type EncodedBatchWriteOperationLike = {
+	operation: string;
+	hashKey: KeyBytes;
+	sortKey: KeyBytes;
+	data?: Uint8Array | string;
+	ttlSeconds?: number;
+	ttlEpochUTCSeconds?: number;
+};
+
 function isEmptyKey(k: string | Uint8Array): boolean {
 	return typeof k === "string" ? k.length === 0 : k.byteLength === 0;
+}
+
+function payloadBytes(data: Uint8Array | string | undefined): number {
+	if (data === undefined) return 0;
+	return typeof data === "string" ? data.length * 2 : data.byteLength;
+}
+
+function validateItemCount(count: number, max: number, emptyMessage: string, tooManyMessage: string): void {
+	if (count === 0) {
+		throw new Error(emptyMessage);
+	}
+	if (count > max) {
+		throw new Error(tooManyMessage);
+	}
+}
+
+function encodedKeyParts(item: ItemKeyLike) {
+	validateItemKeys(item.hashKey, item.sortKey);
+	const hashKey = KeyCodec.encode(item.hashKey);
+	const sortKey = KeyCodec.encodeOptional(item.sortKey);
+	return { hashKey, sortKey };
+}
+
+function encodedPairIdentity(item: ItemKeyLike): string {
+	const { hashKey, sortKey } = encodedKeyParts(item);
+	return `${hashKey.byteLength}:${hashKey.toBase64({ alphabet: "base64url" })}|${sortKey.byteLength}:${sortKey.toBase64({ alphabet: "base64url" })}`;
+}
+
+function validateNoDuplicateKeys(items: readonly ItemKeyLike[], duplicateMessage: (item: ItemKeyLike) => string): void {
+	const seen = new Set<string>();
+	for (const item of items) {
+		const identity = encodedPairIdentity(item);
+		if (seen.has(identity)) {
+			throw new Error(duplicateMessage(item));
+		}
+		seen.add(identity);
+	}
+}
+
+function keyForError(item: ItemKeyLike): { hashKey: string; sortKey: string } {
+	return {
+		hashKey: KeyCodec.keyForLog(KeyCodec.encode(item.hashKey)),
+		sortKey: item.sortKey ? KeyCodec.keyForLog(KeyCodec.encode(item.sortKey)) : "",
+	};
+}
+
+function estimateEncodedKeyPayloadBytes(item: ItemKeyLike): number {
+	const { hashKey, sortKey } = encodedKeyParts(item);
+	return hashKey.byteLength + sortKey.byteLength;
+}
+
+function batchWriteDataBytes(data: Uint8Array | string): number {
+	return typeof data === "string" ? batchWriteTextEncoder.encode(data).byteLength : data.byteLength;
+}
+
+export function estimateBatchWriteForwardedOperationBytes(op: BatchWriteOperationLike): number {
+	const { hashKey, sortKey } = encodedKeyParts(op);
+	return estimateEncodedBatchWriteForwardedOperationBytes({ ...op, hashKey, sortKey });
+}
+
+export function estimateEncodedBatchWriteForwardedOperationBytes(op: EncodedBatchWriteOperationLike): number {
+	const operationOverheadBytes = 32;
+	const keyBytes = op.hashKey.byteLength + op.sortKey.byteLength;
+	if (op.operation === "delete") return operationOverheadBytes + keyBytes;
+	const ttlBytes = op.ttlSeconds !== undefined || op.ttlEpochUTCSeconds !== undefined ? 16 : 0;
+	return operationOverheadBytes + ttlBytes + keyBytes + batchWriteDataBytes(op.data ?? "");
 }
 
 /**
@@ -57,34 +152,83 @@ export function validateItemKeys(hashKey: string | Uint8Array, sortKey?: string 
  * bytes, and that every "put" carries data. Throws on the first violation. Runs on RAW public keys.
  */
 export function validateTransactWriteOperations(ops: readonly TransactWriteOperationLike[]): void {
-	if (ops.length === 0) {
-		throw new Error("fokos: transactWriteItems requires at least 1 item");
-	}
-	if (ops.length > MAX_ITEMS_PER_TRANSACTION) {
-		throw new Error(`fokos: transactWriteItems supports at most ${MAX_ITEMS_PER_TRANSACTION} items`);
-	}
+	validateItemCount(
+		ops.length,
+		MAX_ITEMS_PER_TRANSACTION,
+		"fokos: transactWriteItems requires at least 1 item",
+		`fokos: transactWriteItems supports at most ${MAX_ITEMS_PER_TRANSACTION} items`,
+	);
 	const seen = new Set<string>();
 	let totalBytes = 0;
 	for (const op of ops) {
 		validateItemKeys(op.hashKey, op.sortKey);
 		if (op.operation === "put" && op.data == null) {
-			throw new Error(
-				`fokos: transactWriteItems "put" operation requires data (${KeyCodec.keyForLog(KeyCodec.encode(op.hashKey))}${op.sortKey ? `, ${KeyCodec.keyForLog(KeyCodec.encode(op.sortKey))}` : ""})`,
-			);
+			const { hashKey, sortKey } = keyForError(op);
+			throw new Error(`fokos: transactWriteItems "put" operation requires data (${hashKey}${op.sortKey ? `, ${sortKey}` : ""})`);
 		}
-		// Collision-proof composite identity for arbitrary key bytes.
-		const key = `${op.hashKey.length}:${op.hashKey}:${op.sortKey ?? ""}`;
-		if (seen.has(key)) {
-			throw new Error(
-				`fokos: transactWriteItems duplicate key (${KeyCodec.keyForLog(KeyCodec.encode(op.hashKey))}, ${op.sortKey ? KeyCodec.keyForLog(KeyCodec.encode(op.sortKey)) : ""})`,
-			);
+		const identity = encodedPairIdentity(op);
+		if (seen.has(identity)) {
+			const { hashKey, sortKey } = keyForError(op);
+			throw new Error(`fokos: transactWriteItems duplicate key (${hashKey}, ${sortKey})`);
 		}
-		seen.add(key);
-		if (op.data) {
-			totalBytes += typeof op.data === "string" ? op.data.length * 2 : op.data.byteLength;
-		}
+		seen.add(identity);
+		totalBytes += payloadBytes(op.data);
 	}
 	if (totalBytes > MAX_PAYLOAD_BYTES) {
 		throw new Error(`fokos: transactWriteItems total payload exceeds ${MAX_PAYLOAD_BYTES / (1024 * 1024)} MB`);
+	}
+}
+
+export function validateBatchGetItems(items: readonly ItemKeyLike[]): void {
+	validateItemCount(
+		items.length,
+		MAX_BATCH_GET_ITEMS,
+		"fokos: batchGetItems requires at least 1 item",
+		`fokos: batchGetItems supports at most ${MAX_BATCH_GET_ITEMS} items`,
+	);
+	validateNoDuplicateKeys(items, (item) => {
+		const { hashKey, sortKey } = keyForError(item);
+		return `fokos: batchGetItems duplicate key (${hashKey}, ${sortKey})`;
+	});
+	const totalBytes = items.reduce((sum, item) => sum + estimateEncodedKeyPayloadBytes(item), 0);
+	if (totalBytes > MAX_BATCH_PAYLOAD_BYTES) {
+		throw new Error(`fokos: batchGetItems total payload exceeds ${MAX_BATCH_PAYLOAD_BYTES / (1024 * 1024)} MB`);
+	}
+}
+
+export function validateBatchWriteOperations(ops: readonly BatchWriteOperationLike[]): void {
+	validateItemCount(
+		ops.length,
+		MAX_BATCH_WRITE_ITEMS,
+		"fokos: batchWriteItems requires at least 1 item",
+		`fokos: batchWriteItems supports at most ${MAX_BATCH_WRITE_ITEMS} items`,
+	);
+	let totalBytes = 0;
+	for (const op of ops) {
+		validateItemKeys(op.hashKey, op.sortKey);
+		if (op.operation !== "put" && op.operation !== "delete") {
+			throw new Error(`fokos: batchWriteItems operation must be "put" or "delete" (got ${JSON.stringify(op.operation)})`);
+		}
+		if ("conditions" in op && op.conditions !== undefined) {
+			throw new Error("fokos: batchWriteItems does not support conditions; use transactWriteItems for conditional writes");
+		}
+		if (op.operation === "put" && op.data == null) {
+			const { hashKey, sortKey } = keyForError(op);
+			throw new Error(`fokos: batchWriteItems "put" operation requires data (${hashKey}${op.sortKey ? `, ${sortKey}` : ""})`);
+		}
+		const forwardedBytes = estimateBatchWriteForwardedOperationBytes(op);
+		if (forwardedBytes > MAX_BATCH_FORWARDED_SUB_BATCH_BYTES) {
+			throw new Error(
+				`fokos: batchWriteItems operation payload exceeds ${MAX_BATCH_FORWARDED_SUB_BATCH_BYTES / (1024 * 1024)} MB forwarded sub-batch limit`,
+			);
+		}
+		totalBytes += estimateEncodedKeyPayloadBytes(op) + payloadBytes(op.data);
+	}
+	validateNoDuplicateKeys(ops, (op) => {
+		const { hashKey, sortKey } = keyForError(op);
+		return `fokos: batchWriteItems duplicate key (${hashKey}, ${sortKey})`;
+	});
+	if (totalBytes > MAX_BATCH_PAYLOAD_BYTES) {
+		throw new Error(`fokos: batchWriteItems total payload exceeds ${MAX_BATCH_PAYLOAD_BYTES / (1024 * 1024)} MB`);
 	}
 }

--- a/apps/fokos-svc/src/lib/transaction-limits.ts
+++ b/apps/fokos-svc/src/lib/transaction-limits.ts
@@ -107,6 +107,9 @@ function batchWriteDataBytes(data: Uint8Array | string): number {
 	return typeof data === "string" ? batchWriteTextEncoder.encode(data).byteLength : data.byteLength;
 }
 
+// Public validation receives raw keys, while DO forwarded chunking receives already-encoded KeyBytes.
+// Keep the raw path defined through the encoded estimator so both call sites measure identical bytes;
+// never re-encode KeyBytes, or binary keys double-tag and the [] absent-sort-key sentinel is rejected.
 export function estimateBatchWriteForwardedOperationBytes(op: BatchWriteOperationLike): number {
 	const { hashKey, sortKey } = encodedKeyParts(op);
 	return estimateEncodedBatchWriteForwardedOperationBytes({ ...op, hashKey, sortKey });

--- a/apps/fokos-svc/src/lib/transaction-limits.ts
+++ b/apps/fokos-svc/src/lib/transaction-limits.ts
@@ -54,7 +54,7 @@ function isEmptyKey(k: string | Uint8Array): boolean {
 	return typeof k === "string" ? k.length === 0 : k.byteLength === 0;
 }
 
-function payloadBytes(data: Uint8Array | string | undefined): number {
+export function payloadBytes(data: Uint8Array | string | undefined): number {
 	if (data === undefined) return 0;
 	return typeof data === "string" ? data.length * 2 : data.byteLength;
 }
@@ -75,7 +75,7 @@ function encodedKeyParts(item: ItemKeyLike) {
 	return { hashKey, sortKey };
 }
 
-function encodedPairIdentity(item: ItemKeyLike): string {
+export function encodedPairIdentity(item: ItemKeyLike): string {
 	const { hashKey, sortKey } = encodedKeyParts(item);
 	return `${hashKey.byteLength}:${hashKey.toBase64({ alphabet: "base64url" })}|${sortKey.byteLength}:${sortKey.toBase64({ alphabet: "base64url" })}`;
 }
@@ -91,14 +91,14 @@ function validateNoDuplicateKeys(items: readonly ItemKeyLike[], duplicateMessage
 	}
 }
 
-function keyForError(item: ItemKeyLike): { hashKey: string; sortKey: string } {
+export function keyForError(item: ItemKeyLike): { hashKey: string; sortKey: string } {
 	return {
 		hashKey: KeyCodec.keyForLog(KeyCodec.encode(item.hashKey)),
 		sortKey: item.sortKey ? KeyCodec.keyForLog(KeyCodec.encode(item.sortKey)) : "",
 	};
 }
 
-function estimateEncodedKeyPayloadBytes(item: ItemKeyLike): number {
+export function estimateEncodedKeyPayloadBytes(item: ItemKeyLike): number {
 	const { hashKey, sortKey } = encodedKeyParts(item);
 	return hashKey.byteLength + sortKey.byteLength;
 }

--- a/apps/fokos-svc/src/lib/types.ts
+++ b/apps/fokos-svc/src/lib/types.ts
@@ -108,7 +108,6 @@ export type BatchWriteItemsOptions = {
 
 export type BatchRetryableFailureReason =
 	| { type: "pending_lock"; conflictingTransactionId?: string }
-	| { type: "migration_in_progress" }
 	| { type: "partition_over_limit" }
 	| { type: "transient_error"; message?: string };
 

--- a/apps/fokos-svc/src/lib/types.ts
+++ b/apps/fokos-svc/src/lib/types.ts
@@ -1,4 +1,4 @@
-export interface FokosDBAPI extends ItemPutter, ItemGetter, ItemDeleter {}
+export interface FokosDBAPI extends ItemPutter, ItemGetter, ItemDeleter, BatchItemGetter, BatchItemWriter {}
 
 export interface ItemPutter {
 	putItem(opts: PutItemOptions): Promise<PutItemResult>;
@@ -74,6 +74,104 @@ export type GetItemResult =
 			item: ItemKey;
 			meta: OperationMetrics & PartitionInfo & {};
 	  };
+
+export interface BatchItemGetter {
+	batchGetItems(opts: BatchGetItemsOptions): Promise<BatchGetItemsResult>;
+}
+
+export interface BatchItemWriter {
+	batchWriteItems(opts: BatchWriteItemsOptions): Promise<BatchWriteItemsResult>;
+}
+
+export type BatchGetItemsOptions = {
+	items: ItemKey[];
+};
+
+export type BatchWriteItemOperation =
+	| {
+			operation: "put";
+			hashKey: string | Uint8Array;
+			sortKey?: string | Uint8Array;
+			ttlSeconds?: number;
+			ttlEpochUTCSeconds?: number;
+			data: Uint8Array | string;
+	  }
+	| {
+			operation: "delete";
+			hashKey: string | Uint8Array;
+			sortKey?: string | Uint8Array;
+	  };
+
+export type BatchWriteItemsOptions = {
+	operations: BatchWriteItemOperation[];
+};
+
+export type BatchRetryableFailureReason =
+	| { type: "pending_lock"; conflictingTransactionId?: string }
+	| { type: "migration_in_progress" }
+	| { type: "partition_over_limit" }
+	| { type: "transient_error"; message?: string };
+
+export type BatchItemsMeta = {
+	requestedCount: number;
+	processedCount: number;
+	unprocessedCount: number;
+	rowsRead: number;
+	rowsWritten: number;
+	forwardCount: number;
+	partitionsVisited: number;
+};
+
+export type BatchGetProcessedItem =
+	| {
+			inputIndex: number;
+			found: true;
+			item: {
+				hashKey: string | Uint8Array;
+				sortKey?: string | Uint8Array;
+				data: Uint8Array | string;
+				ttlEpochUTCSeconds?: number;
+				version: number;
+			};
+	  }
+	| {
+			inputIndex: number;
+			found: false;
+			item: ItemKey;
+	  };
+
+export type BatchGetUnprocessedKey = {
+	inputIndex: number;
+	item: ItemKey;
+	reason: BatchRetryableFailureReason;
+};
+
+export type BatchGetItemsResult = {
+	items: BatchGetProcessedItem[];
+	unprocessedKeys: BatchGetUnprocessedKey[];
+	meta: BatchItemsMeta;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
+
+export type BatchWriteProcessedItem = {
+	inputIndex: number;
+	operation: BatchWriteItemOperation["operation"];
+	item: ItemKey;
+};
+
+export type BatchWriteUnprocessedItem = {
+	inputIndex: number;
+	operation: BatchWriteItemOperation["operation"];
+	item: ItemKey;
+	reason: BatchRetryableFailureReason;
+};
+
+export type BatchWriteItemsResult = {
+	processedItems: BatchWriteProcessedItem[];
+	unprocessedItems: BatchWriteUnprocessedItem[];
+	meta: BatchItemsMeta;
+	partitionMetas: Array<OperationMetrics & PartitionInfo>;
+};
 
 export type PartitionInfo = {
 	/**

--- a/apps/fokos-svc/test/http-batch.test.ts
+++ b/apps/fokos-svc/test/http-batch.test.ts
@@ -1,0 +1,286 @@
+import { env, exports } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MAX_BATCH_FORWARDED_SUB_BATCH_BYTES, MAX_BATCH_GET_ITEMS, MAX_BATCH_WRITE_ITEMS } from "../src/lib/transaction-limits.js";
+
+const TOKEN = "test-token";
+const PARTITION_OPTIONS = {
+	rootTreesN: 1,
+	hashSplitN: 2,
+	rangeSplitN: 2,
+	hashSplitConditions: { maxSizeMb: 10 },
+	rangeSplitConditions: { maxSizeMb: 10 },
+};
+
+type BatchGetHttpResult = {
+	items: Array<{
+		inputIndex: number;
+		found: boolean;
+		item: {
+			hashKey: string;
+			sortKey?: string;
+			data?: string;
+			dataEncoding?: "utf8" | "base64";
+			version?: number;
+		};
+	}>;
+	unprocessedKeys: unknown[];
+	meta: {
+		requestedCount: number;
+		processedCount: number;
+		unprocessedCount: number;
+		rowsRead: number;
+		rowsWritten: number;
+		forwardCount: number;
+		partitionsVisited: number;
+	};
+	partitionMetas: Array<{ rowsRead: number; rowsWritten: number; forwardCount: number; servedByActorName: string }>;
+};
+
+type BatchWriteHttpResult = {
+	processedItems: Array<{ inputIndex: number; operation: "put" | "delete"; item: { hashKey: string; sortKey?: string } }>;
+	unprocessedItems: unknown[];
+	meta: {
+		requestedCount: number;
+		processedCount: number;
+		unprocessedCount: number;
+		rowsRead: number;
+		rowsWritten: number;
+		forwardCount: number;
+		partitionsVisited: number;
+	};
+	partitionMetas: Array<{ rowsRead: number; rowsWritten: number; forwardCount: number; servedByActorName: string }>;
+};
+
+type GetItemHttpResult =
+	| { found: true; item: { hashKey: string; sortKey?: string; data: string; dataEncoding: "utf8" | "base64"; version: number } }
+	| { found: false; item: { hashKey: string; sortKey?: string } };
+
+beforeEach(() => {
+	(env as unknown as { FOKOS_API_TOKENS: string }).FOKOS_API_TOKENS = TOKEN;
+});
+
+function tableName(): string {
+	return `httpbatch.${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+async function rpc(table: string, rpcAction: string, body: unknown): Promise<Response> {
+	return exports.default.fetch(`https://example.com/api/rpc/${table}/${rpcAction}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "x-fokos-secret-token": TOKEN },
+		body: JSON.stringify(body),
+	});
+}
+
+async function expectOkJson<T>(response: Response): Promise<T> {
+	const text = await response.text();
+	expect(response.status, text).toBe(200);
+	return JSON.parse(text) as T;
+}
+
+async function expectValidationFailure(table: string, rpcAction: string, body: unknown, expected: RegExp): Promise<void> {
+	const response = await rpc(table, rpcAction, body);
+	const text = await response.text();
+	expect(response.status, text).toBe(400);
+	expect(text).toMatch(expected);
+}
+
+describe("HTTP batch item RPCs", () => {
+	it("batchGetItems returns found and missing items in request order with serialized data and meta", async () => {
+		const table = tableName();
+		await expectOkJson(
+			await rpc(table, "putItem", {
+				hashKey: "http-get-a",
+				sortKey: "sk",
+				data: "alpha",
+				partitionOptions: PARTITION_OPTIONS,
+			}),
+		);
+		await expectOkJson(
+			await rpc(table, "putItem", {
+				hashKey: "http-get-b",
+				data: "bravo",
+				partitionOptions: PARTITION_OPTIONS,
+			}),
+		);
+
+		const result = await expectOkJson<BatchGetHttpResult>(
+			await rpc(table, "batchGetItems", {
+				items: [{ hashKey: "http-get-a", sortKey: "sk" }, { hashKey: "http-missing" }, { hashKey: "http-get-b" }],
+				partitionOptions: PARTITION_OPTIONS,
+			}),
+		);
+
+		expect(result.items).toEqual([
+			{
+				inputIndex: 0,
+				found: true,
+				item: { hashKey: "http-get-a", sortKey: "sk", data: "alpha", dataEncoding: "utf8", version: 1 },
+			},
+			{ inputIndex: 1, found: false, item: { hashKey: "http-missing" } },
+			{ inputIndex: 2, found: true, item: { hashKey: "http-get-b", data: "bravo", dataEncoding: "utf8", version: 1 } },
+		]);
+		expect(result.unprocessedKeys).toEqual([]);
+		expect(result.meta).toEqual({
+			requestedCount: 3,
+			processedCount: 3,
+			unprocessedCount: 0,
+			rowsRead: 2,
+			rowsWritten: 0,
+			forwardCount: 0,
+			partitionsVisited: 1,
+		});
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0]).toMatchObject({ rowsRead: 2, rowsWritten: 0, forwardCount: 0 });
+		expect(result.partitionMetas[0].servedByActorName).toContain(table);
+	});
+
+	it("batchWriteItems applies put/delete operations and returns processed shape without versions", async () => {
+		const table = tableName();
+		await expectOkJson(
+			await rpc(table, "putItem", {
+				hashKey: "http-existing",
+				data: "old",
+				partitionOptions: PARTITION_OPTIONS,
+			}),
+		);
+
+		const result = await expectOkJson<BatchWriteHttpResult>(
+			await rpc(table, "batchWriteItems", {
+				operations: [
+					{ operation: "put", hashKey: "http-created", data: "new" },
+					{ operation: "delete", hashKey: "http-existing" },
+				],
+				partitionOptions: PARTITION_OPTIONS,
+			}),
+		);
+
+		expect(result.processedItems).toEqual([
+			{ inputIndex: 0, operation: "put", item: { hashKey: "http-created" } },
+			{ inputIndex: 1, operation: "delete", item: { hashKey: "http-existing" } },
+		]);
+		expect("version" in result.processedItems[0]).toBe(false);
+		expect(result.unprocessedItems).toEqual([]);
+		expect(result.meta).toMatchObject({
+			requestedCount: 2,
+			processedCount: 2,
+			unprocessedCount: 0,
+			forwardCount: 0,
+			partitionsVisited: 1,
+		});
+		expect(result.meta.rowsWritten).toBeGreaterThan(0);
+		expect(result.partitionMetas).toHaveLength(1);
+		expect(result.partitionMetas[0].rowsWritten).toBeGreaterThan(0);
+
+		const created = await expectOkJson<GetItemHttpResult>(
+			await rpc(table, "getItem", { hashKey: "http-created", partitionOptions: PARTITION_OPTIONS }),
+		);
+		expect(created).toMatchObject({ found: true, item: { data: "new", dataEncoding: "utf8", version: 1 } });
+
+		const deleted = await expectOkJson<GetItemHttpResult>(
+			await rpc(table, "getItem", { hashKey: "http-existing", partitionOptions: PARTITION_OPTIONS }),
+		);
+		expect(deleted).toMatchObject({ found: false, item: { hashKey: "http-existing" } });
+	});
+
+	it("rejects invalid batch request shapes during HTTP validation", async () => {
+		const table = tableName();
+		await expectValidationFailure(
+			table,
+			"batchGetItems",
+			{ items: [], partitionOptions: PARTITION_OPTIONS },
+			/batchGetItems requires at least 1 item/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchGetItems",
+			{
+				items: Array.from({ length: MAX_BATCH_GET_ITEMS + 1 }, (_, index) => ({ hashKey: `too-many-get-${index}` })),
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/batchGetItems supports at most 100 items/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchGetItems",
+			{ items: [{ hashKey: "duplicate-get" }, { hashKey: "duplicate-get" }], partitionOptions: PARTITION_OPTIONS },
+			/batchGetItems duplicate key/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchGetItems",
+			{ items: [{ hashKey: "" }], partitionOptions: PARTITION_OPTIONS },
+			/hashKey must not be empty/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{ operations: [], partitionOptions: PARTITION_OPTIONS },
+			/batchWriteItems requires at least 1 item/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{
+				operations: Array.from({ length: MAX_BATCH_WRITE_ITEMS + 1 }, (_, index) => ({
+					operation: "put",
+					hashKey: `too-many-write-${index}`,
+					data: "x",
+				})),
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/batchWriteItems supports at most 25 items/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{
+				operations: [
+					{ operation: "put", hashKey: "duplicate-write", data: "x" },
+					{ operation: "delete", hashKey: "duplicate-write" },
+				],
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/batchWriteItems duplicate key/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{
+				operations: [
+					{
+						operation: "put",
+						hashKey: "too-large-forwarded-op",
+						data: "x".repeat(MAX_BATCH_FORWARDED_SUB_BATCH_BYTES + 1),
+					},
+				],
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/batchWriteItems operation payload exceeds 1 MB forwarded sub-batch limit/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{
+				operations: [{ operation: "put", hashKey: "conditional", data: "x", conditions: [{ type: "item_exists" }] }],
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/conditions/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{ operations: [{ operation: "check", hashKey: "checked" }], partitionOptions: PARTITION_OPTIONS },
+			/check|operation/,
+		);
+		await expectValidationFailure(
+			table,
+			"batchWriteItems",
+			{
+				operations: [{ operation: "put", hashKey: "with-token", data: "x" }],
+				clientRequestToken: "not-supported-for-batch-write",
+				partitionOptions: PARTITION_OPTIONS,
+			},
+			/clientRequestToken/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds native non-transactional batch item operations for FokosDB:

- `FokosDB.batchGetItems({ items })`
- `FokosDB.batchWriteItems({ operations })`
- HTTP RPC actions for `batchGetItems` and `batchWriteItems`
- `FokosStd.batchGetAll` / `batchWriteAll` helpers for chunking and bounded retry
- validation, split/migration forwarding, partial-failure handling, and docs cleanup

This is FokosDB-native batch behavior, not full DynamoDB API parity.

## Notes

- Batch writes are non-atomic and condition-free; conditional writes remain under `transactWriteItems`.
- Duplicate keys and hard size/count validation errors reject before work starts.
- Runtime retryable failures are returned as `unprocessedKeys` / `unprocessedItems`.
- `FokosStd` retries only unprocessed entries, preserves original `inputIndex`, and documents that batch write retries are safe but not version-idempotent.
- Final review fixes removed the unused `migration_in_progress` failure reason, made batchGet fail loudly on impossible `inputIndex` corruption, and removed an internal retry-reason alias.
- Task anchor: user-approved task `batch-item-ops`.

## Verification

```sh
cd /Users/MN/GITHUB/lambrospetrou/fokosdb/apps/fokos-svc && npm run test
```

Passed locally on 2026-06-30:

- TypeScript + Prettier check passed
- Key invariant check passed
- Vitest: 23 passed | 1 skipped files; 451 passed | 3 skipped tests
- Follow-up PR review: pr-reviewer-a and pr-reviewer-b both reported no blockers on the final seven-file review-fix patch

Known local test noise remains unchanged: missing `FOKOS_API_TOKENS` warnings and intentional worker-pool background exception traces from existing split/migration retry fixtures.
