### PR TITLE
Add package build and exports

### DIFF
--- a/apps/fokos-svc/package-lock.json
+++ b/apps/fokos-svc/package-lock.json
@@ -7,20 +7,22 @@
 		"": {
 			"name": "fokos-svc",
 			"version": "0.0.0",
+			"dependencies": {
+				"durable-utils": "^0.3.7",
+				"xxhash-wasm": "^1.1.0"
+			},
 			"devDependencies": {
 				"@cloudflare/vitest-pool-workers": "^0.16.9",
 				"@orangeopensource/hurl": "^8.0.1",
 				"@types/node": "^25.6.0",
 				"dotenv-cli": "^11.0.0",
-				"durable-utils": "^0.3.7",
 				"hono": "^4.12.22",
 				"js-xxhash": "^5.0.1",
 				"prettier": "3.8.3",
 				"typescript": "^5.9.3",
 				"valibot": "^1.4.0",
 				"vitest": "^4.1.7",
-				"wrangler": "^4.94.0",
-				"xxhash-wasm": "^1.1.0"
+				"wrangler": "^4.94.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -1888,7 +1890,6 @@
 			"version": "0.3.7",
 			"resolved": "https://registry.npmjs.org/durable-utils/-/durable-utils-0.3.7.tgz",
 			"integrity": "sha512-7WW01kg50gF2rKQtU5s+WkQnlWL6vz1o1uBOPVNVfV+U51Kmi56zwgAxUTy+9PvNq24WS3N5IT9AYKvn6nJe5A==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
@@ -3211,7 +3212,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
 			"integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yallist": {

--- a/apps/fokos-svc/package.json
+++ b/apps/fokos-svc/package.json
@@ -3,8 +3,42 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		"./db": {
+			"types": "./dist/db.d.ts",
+			"default": "./dist/db.js"
+		},
+		"./do-partition": {
+			"types": "./dist/do-partition.d.ts",
+			"default": "./dist/do-partition.js"
+		},
+		"./do-transaction-coordinator": {
+			"types": "./dist/do-transaction-coordinator.d.ts",
+			"default": "./dist/do-transaction-coordinator.js"
+		},
+		"./partition-context": {
+			"types": "./dist/partition-topology/partition-context.d.ts",
+			"default": "./dist/partition-topology/partition-context.js"
+		},
+		"./router": {
+			"types": "./dist/partition-topology/router.d.ts",
+			"default": "./dist/partition-topology/router.js"
+		},
+		"./transaction-types": {
+			"types": "./dist/transaction-types.d.ts",
+			"default": "./dist/transaction-types.js"
+		},
+		"./types": {
+			"types": "./dist/types.d.ts",
+			"default": "./dist/types.js"
+		}
+	},
 	"scripts": {
 		"bench:expression": "vitest bench --config vitest.benchmark.config.ts",
+		"build": "tsc -p tsconfig.build.json",
 		"check": "tsc --noEmit && tsc --noEmit -p src/examples/http-api && prettier --check .",
 		"check:keys": "bash tools/check-key-invariants.sh",
 		"fmt": "prettier --write .",
@@ -16,21 +50,24 @@
 		"test:hurl:run": "npx dotenv -e test/hurl/.env.dev-hurl --  hurl --variables-file test/hurl/vars.env --test --report-json test/hurl/report-json --connect-timeout 2",
 		"pretest:hurl:remote": "rm -rf test/hurl/report-json && mkdir -p test/hurl/report-json",
 		"test:hurl:remote": "npx dotenv -e test/hurl/.env.production-hurl -- hurl --variables-file test/hurl/vars_remote.env --test --report-json test/hurl/report-json --connect-timeout 2",
-		"cf-typegen": "wrangler types && wrangler types -c src/examples/http-api/wrangler.jsonc src/examples/http-api/worker-configuration.d.ts"
+		"cf-typegen": "wrangler types && wrangler types -c src/examples/http-api/wrangler.jsonc src/examples/http-api/worker-configuration.d.ts",
+		"prepare": "npm run build"
+	},
+	"dependencies": {
+		"durable-utils": "^0.3.7",
+		"xxhash-wasm": "^1.1.0"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.16.9",
 		"@orangeopensource/hurl": "^8.0.1",
 		"@types/node": "^25.6.0",
 		"dotenv-cli": "^11.0.0",
-		"durable-utils": "^0.3.7",
 		"hono": "^4.12.22",
 		"js-xxhash": "^5.0.1",
 		"prettier": "3.8.3",
 		"typescript": "^5.9.3",
 		"valibot": "^1.4.0",
 		"vitest": "^4.1.7",
-		"wrangler": "^4.94.0",
-		"xxhash-wasm": "^1.1.0"
+		"wrangler": "^4.94.0"
 	}
 }

--- a/apps/fokos-svc/tsconfig.build.json
+++ b/apps/fokos-svc/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"declaration": true,
+		"declarationMap": true,
+		"noEmit": false,
+		"outDir": "./dist",
+		"rootDir": "./src/lib",
+		"sourceMap": true
+	},
+	"include": ["./src/lib/**/*.ts", "./src/uint8array-hex.d.ts", "./worker-configuration.d.ts"],
+	"exclude": ["./src/lib/**/*.bench.ts", "./src/lib/**/*.test.ts", "./src/lib/**/test-fixtures.ts"]
+}


### PR DESCRIPTION
Emit JavaScript and declarations during Git dependency preparation so consumers do not need to compile the TypeScript sources directly.